### PR TITLE
Feat/notifications and audit

### DIFF
--- a/admin-dashboard/app/dashboard/page.tsx
+++ b/admin-dashboard/app/dashboard/page.tsx
@@ -19,7 +19,7 @@ import { currentSession, signOut } from "@/lib/cognito"
 import { api } from "@/lib/api"
 import { ThemeToggle } from "@/components/theme-toggle"
 import {
-  Submission, StatusResponse, Permissions, STATUSES, labelFor, Package, PackageFile,
+  Submission, StatusResponse, Permissions, STATUSES, labelFor, Package, PackageFile, AuditEntry, AuditResponse,
 } from "@/lib/types"
 
 const STATUS_STYLES: Record<Submission["status"], string> = {
@@ -28,6 +28,17 @@ const STATUS_STYLES: Record<Submission["status"], string> = {
   "under-review": "bg-blue-100 text-blue-800 border-blue-300",
   approved: "bg-emerald-100 text-emerald-900 border-emerald-300",
   denied: "bg-red-100 text-red-800 border-red-300",
+}
+
+function formatAudit(e: AuditEntry): string {
+  const d = e.details || {}
+  if (e.action === "status_change") {
+    return `Status: ${(d.from as string) || "—"} → ${(d.to as string) || "—"}`
+  }
+  if (e.action === "delete") {
+    return `Deleted (${(d.filesDeleted as number) ?? 0} files)`
+  }
+  return e.action
 }
 
 export default function DashboardPage() {
@@ -217,6 +228,7 @@ function SubmissionDetail({ submission }: { submission: Submission }) {
   const [pkg, setPkg] = useState<Package | null>(null)
   const [active, setActive] = useState<PackageFile | null>(null)
   const [err, setErr] = useState("")
+  const [audit, setAudit] = useState<AuditEntry[] | null>(null)
 
   useEffect(() => {
     (async () => {
@@ -228,6 +240,19 @@ function SubmissionDetail({ submission }: { submission: Submission }) {
         if (data.files.length) setActive(data.files[0])
       } catch (e) {
         setErr(e instanceof Error ? e.message : String(e))
+      }
+    })()
+  }, [submission.submissionId])
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const res = await api(`/audit/${encodeURIComponent(submission.submissionId)}`)
+        if (!res.ok) return
+        const data: AuditResponse = await res.json()
+        setAudit(data.entries)
+      } catch {
+        // audit is best-effort in the UI too
       }
     })()
   }, [submission.submissionId])
@@ -266,6 +291,21 @@ function SubmissionDetail({ submission }: { submission: Submission }) {
                   >
                     📄 {f.filename}
                   </button>
+                </li>
+              ))}
+            </ul>
+          </div>
+          <div>
+            <p className="font-medium">Activity</p>
+            {audit === null && <p className="text-muted-foreground text-xs mt-1">Loading…</p>}
+            {audit && audit.length === 0 && <p className="text-muted-foreground text-xs mt-1">No changes logged.</p>}
+            <ul className="mt-1 space-y-2">
+              {audit?.map((e, i) => (
+                <li key={i} className="text-xs">
+                  <div className="text-foreground">{formatAudit(e)}</div>
+                  <div className="text-muted-foreground">
+                    {e.actor} · {new Date(e.timestamp).toLocaleString()}
+                  </div>
                 </li>
               ))}
             </ul>

--- a/admin-dashboard/lib/types.ts
+++ b/admin-dashboard/lib/types.ts
@@ -1,3 +1,16 @@
+export type AuditEntry = {
+  submissionId: string
+  timestamp: string
+  actor: string
+  action: string
+  details: Record<string, unknown>
+}
+
+export type AuditResponse = {
+  submissionId: string
+  entries: AuditEntry[]
+}
+
 export type PackageFile = { filename: string; downloadUrl: string; size: number }
 
 export type Package = {

--- a/bot/infrastructure.py
+++ b/bot/infrastructure.py
@@ -7,6 +7,7 @@ from aws_cdk import (
     aws_s3 as s3,
     aws_s3_deployment as s3deploy,
     aws_lambda as _lambda,
+    aws_lambda_event_sources as lambda_events,
     aws_iam as iam,
     aws_lex as lex,
     aws_connect as connect,
@@ -19,6 +20,7 @@ from aws_cdk import (
     aws_codebuild as codebuild,
     aws_cloudfront as cloudfront,
     aws_cloudfront_origins as cloudfront_origins,
+    aws_ses as ses,
     custom_resources as cr,
 )
 from constructs import Construct
@@ -473,6 +475,7 @@ class NovaSonicConnectStack(Stack):
             partition_key=dynamodb.Attribute(name="submissionId", type=dynamodb.AttributeType.STRING),
             billing_mode=dynamodb.BillingMode.PAY_PER_REQUEST,
             removal_policy=RemovalPolicy.DESTROY,
+            stream=dynamodb.StreamViewType.NEW_AND_OLD_IMAGES,
         )
 
         # Admin config: departments, users, refund-type labels (super-admin managed)
@@ -847,3 +850,48 @@ class NovaSonicConnectStack(Stack):
 
         CfnOutput(self, "AdminDashboardUrl", value=f"https://{admin_distribution.distribution_domain_name}")
         CfnOutput(self, "AdminBuildProjectName", value=admin_build.project_name)
+
+        # --- Notifications (DynamoDB stream → Lambda → SES) ---
+        notif_cfg = cfg.get("notifications") or {}
+        notif_mode = notif_cfg.get("mode", "ses")
+        notif_sender = notif_cfg.get("sender", "")
+
+        # SES identity — creating the resource sends a verification email on deploy.
+        # Idempotent; if the identity already exists, CFN no-ops.
+        if notif_sender:
+            ses.EmailIdentity(
+                self, "NotificationSenderIdentity",
+                identity=ses.Identity.email(notif_sender),
+            )
+
+        notif_fn = _lambda.Function(
+            self, "NotificationHandler",
+            function_name=f"{proj}-notification-handler",
+            runtime=_lambda.Runtime.PYTHON_3_12,
+            handler="lambda_function.lambda_handler",
+            code=_lambda.Code.from_asset("bot/notification_handler"),
+            timeout=Duration.seconds(30),
+            memory_size=128,
+            environment={
+                "ADMIN_CONFIG_TABLE": admin_config_table.table_name,
+                "USER_POOL_ID": user_pool.user_pool_id,
+                "DASHBOARD_URL": f"https://{admin_distribution.distribution_domain_name}/dashboard",
+                "SES_SENDER": notif_sender,
+                "NOTIFICATIONS_MODE": notif_mode,
+            },
+        )
+        admin_config_table.grant_read_data(notif_fn)
+        notif_fn.add_to_role_policy(iam.PolicyStatement(
+            actions=["cognito-idp:ListUsersInGroup"],
+            resources=[user_pool.user_pool_arn],
+        ))
+        notif_fn.add_to_role_policy(iam.PolicyStatement(
+            actions=["ses:SendEmail", "ses:SendRawEmail"],
+            resources=["*"],
+        ))
+        notif_fn.add_event_source(lambda_events.DynamoEventSource(
+            submissions_table,
+            starting_position=_lambda.StartingPosition.LATEST,
+            batch_size=10,
+            retry_attempts=2,
+        ))

--- a/bot/infrastructure.py
+++ b/bot/infrastructure.py
@@ -468,14 +468,25 @@ class NovaSonicConnectStack(Stack):
             ],
         )
 
-        # DynamoDB table for claim submissions
+        # Single application table: submissions + per-submission audit + future
+        # per-submission entities. Single-table pattern with pk+sk.
+        #   pk = SUBMISSION#<id>     sk = META         → submission record
+        #   pk = SUBMISSION#<id>     sk = AUDIT#<ts>   → audit entry
+        # GSI "listIx" exposes SUBMISSION_LIST for efficient queries over all
+        # submissions, sorted by submittedAt.
         submissions_table = dynamodb.Table(
-            self, "ClaimSubmissions",
-            table_name=f"{proj}-claim-submissions",
-            partition_key=dynamodb.Attribute(name="submissionId", type=dynamodb.AttributeType.STRING),
+            self, "AppData",
+            table_name=f"{proj}-app-data",
+            partition_key=dynamodb.Attribute(name="pk", type=dynamodb.AttributeType.STRING),
+            sort_key=dynamodb.Attribute(name="sk", type=dynamodb.AttributeType.STRING),
             billing_mode=dynamodb.BillingMode.PAY_PER_REQUEST,
             removal_policy=RemovalPolicy.DESTROY,
             stream=dynamodb.StreamViewType.NEW_AND_OLD_IMAGES,
+        )
+        submissions_table.add_global_secondary_index(
+            index_name="listIx",
+            partition_key=dynamodb.Attribute(name="gsi1pk", type=dynamodb.AttributeType.STRING),
+            sort_key=dynamodb.Attribute(name="gsi1sk", type=dynamodb.AttributeType.STRING),
         )
 
         # Admin config: departments, users, refund-type labels (super-admin managed)
@@ -662,6 +673,11 @@ class NovaSonicConnectStack(Stack):
         )
         upload_api.root.add_resource("delete-submission").add_method(
             "POST", apigw.LambdaIntegration(upload_fn), authorizer=authorizer,
+            authorization_type=apigw.AuthorizationType.COGNITO,
+        )
+        audit_resource = upload_api.root.add_resource("audit").add_resource("{submissionId}")
+        audit_resource.add_method(
+            "GET", apigw.LambdaIntegration(upload_fn), authorizer=authorizer,
             authorization_type=apigw.AuthorizationType.COGNITO,
         )
 

--- a/bot/notification_handler/lambda_function.py
+++ b/bot/notification_handler/lambda_function.py
@@ -144,6 +144,11 @@ def lambda_handler(event: dict[str, Any], context: Any) -> None:
         new_image = _unwrap_image(dynamo.get("NewImage") or {})
         old_image = _unwrap_image(dynamo.get("OldImage") or {})
 
+        # Only notify on META rows (the submission record itself), not on
+        # audit or other sort-key partitions.
+        if new_image.get("sk") != "META" and old_image.get("sk") != "META":
+            continue
+
         kind = None
         if event_name == "INSERT":
             kind = "new"

--- a/bot/notification_handler/lambda_function.py
+++ b/bot/notification_handler/lambda_function.py
@@ -1,0 +1,169 @@
+"""DynamoDB-streams notification Lambda.
+
+Fires on every write to the ClaimSubmissions table. Sends emails to admins in
+departments matching the submission's refund types. Two event kinds:
+  - INSERT: new submission started → subject "New submission started"
+  - MODIFY (status partial → complete): ready for review → subject
+    "Submission ready for review"
+
+Super-admins are excluded from notifications per spec.
+"""
+
+import json
+import logging
+import os
+from typing import Any
+
+import boto3
+from botocore.exceptions import ClientError
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+ses = boto3.client("ses")
+dynamodb = boto3.resource("dynamodb")
+cognito = boto3.client("cognito-idp")
+
+ADMIN_CONFIG_TABLE = os.environ["ADMIN_CONFIG_TABLE"]
+USER_POOL_ID = os.environ["USER_POOL_ID"]
+DASHBOARD_URL = os.environ.get("DASHBOARD_URL", "")
+SENDER = os.environ["SES_SENDER"]
+MODE = os.environ.get("NOTIFICATIONS_MODE", "ses")
+
+admin_table = dynamodb.Table(ADMIN_CONFIG_TABLE)
+
+
+def _unwrap(attr: dict[str, Any]) -> Any:
+    """Minimal DynamoDB Stream type unwrapper."""
+    if "S" in attr: return attr["S"]
+    if "N" in attr: return attr["N"]
+    if "BOOL" in attr: return attr["BOOL"]
+    if "L" in attr: return [_unwrap(v) for v in attr["L"]]
+    if "M" in attr: return {k: _unwrap(v) for k, v in attr["M"].items()}
+    if "NULL" in attr: return None
+    if "SS" in attr: return list(attr["SS"])
+    return None
+
+
+def _unwrap_image(image: dict[str, Any]) -> dict[str, Any]:
+    return {k: _unwrap(v) for k, v in image.items()}
+
+
+def _load_departments() -> list[dict[str, Any]]:
+    resp = admin_table.scan(
+        FilterExpression="begins_with(pk, :p)",
+        ExpressionAttributeValues={":p": "DEPT#"},
+    )
+    return resp.get("Items", [])
+
+
+def _departments_for_types(refund_types: list[str]) -> list[str]:
+    depts = set()
+    for d in _load_departments():
+        if any(rt in (d.get("refund_types") or []) for rt in refund_types):
+            depts.add(d["key"])
+    return sorted(depts)
+
+
+def _recipients_for_departments(dept_keys: list[str]) -> list[str]:
+    emails: set[str] = set()
+    for key in dept_keys:
+        group = f"admin-{key}"
+        try:
+            users = cognito.list_users_in_group(UserPoolId=USER_POOL_ID, GroupName=group)
+        except cognito.exceptions.ResourceNotFoundException:
+            continue
+        for u in users.get("Users", []):
+            attrs = {a["Name"]: a["Value"] for a in u.get("Attributes", [])}
+            email = attrs.get("email")
+            if email:
+                emails.add(email)
+    return sorted(emails)
+
+
+def _send(recipients: list[str], subject: str, body_text: str):
+    if not recipients:
+        logger.info("No recipients — skipping.")
+        return
+    if MODE != "ses":
+        logger.info("LOG MODE: subject=%s recipients=%s body=%s", subject, recipients, body_text)
+        return
+    for to in recipients:
+        try:
+            ses.send_email(
+                Source=SENDER,
+                Destination={"ToAddresses": [to]},
+                Message={
+                    "Subject": {"Data": subject},
+                    "Body": {"Text": {"Data": body_text}},
+                },
+            )
+            logger.info("Sent '%s' to %s", subject, to)
+        except ClientError as e:
+            code = e.response.get("Error", {}).get("Code", "")
+            # Fall back to logging when the sender isn't verified yet.
+            if code in ("MessageRejected", "MailFromDomainNotVerifiedException"):
+                logger.warning("SES rejected (likely unverified sender). Logging instead. to=%s subject=%s body=%s",
+                               to, subject, body_text)
+            else:
+                raise
+
+
+def _format_email(submission: dict[str, Any], kind: str) -> tuple[str, str]:
+    name = submission.get("name", "(no name)")
+    sid = submission.get("submissionId", "")
+    types = submission.get("refundType", "")
+    dashboard = DASHBOARD_URL or "(dashboard URL not configured)"
+    if kind == "new":
+        subject = f"New submission started — {name}"
+        body = (
+            f"A new unclaimed refund submission has been started.\n\n"
+            f"Claimant: {name}\n"
+            f"Refund type(s): {types}\n"
+            f"Submission ID: {sid}\n\n"
+            f"Documents may still be uploading. Check the dashboard for status:\n"
+            f"{dashboard}\n"
+        )
+    else:  # ready
+        subject = f"Submission ready for review — {name}"
+        body = (
+            f"A submission has completed document upload and is ready for review.\n\n"
+            f"Claimant: {name}\n"
+            f"Refund type(s): {types}\n"
+            f"Submission ID: {sid}\n\n"
+            f"Review on the dashboard:\n"
+            f"{dashboard}\n"
+        )
+    return subject, body
+
+
+def lambda_handler(event: dict[str, Any], context: Any) -> None:
+    for record in event.get("Records", []):
+        event_name = record.get("eventName")
+        dynamo = record.get("dynamodb", {})
+        new_image = _unwrap_image(dynamo.get("NewImage") or {})
+        old_image = _unwrap_image(dynamo.get("OldImage") or {})
+
+        kind = None
+        if event_name == "INSERT":
+            kind = "new"
+        elif event_name == "MODIFY":
+            old_status = old_image.get("status")
+            new_status = new_image.get("status")
+            if old_status == "partial" and new_status == "complete":
+                kind = "ready"
+
+        if not kind or not new_image:
+            continue
+
+        refund_types = [
+            t.strip() for t in (new_image.get("refundType") or "").split(",") if t.strip()
+        ]
+        dept_keys = new_image.get("departments") or _departments_for_types(refund_types)
+        if not dept_keys:
+            logger.info("No departments map to %s; skipping notification.", refund_types)
+            continue
+
+        recipients = _recipients_for_departments(dept_keys)
+        subject, body = _format_email(new_image, kind)
+        _send(recipients, subject, body)

--- a/bot/upload_handler/lambda_function.py
+++ b/bot/upload_handler/lambda_function.py
@@ -149,6 +149,97 @@ def _auth(event: dict[str, Any]) -> tuple[set[str], bool]:
     return dept_keys, is_super
 
 
+def _actor(event: dict[str, Any]) -> str:
+    """Return the Cognito username of the caller, or 'unknown' if missing."""
+    claims = ((event.get("requestContext") or {}).get("authorizer") or {}).get("claims") or {}
+    return claims.get("cognito:username") or claims.get("username") or "unknown"
+
+
+def _audit(submission_id: str, actor: str, action: str, details: dict[str, Any]) -> None:
+    """Record a change to a submission. Non-fatal on failure."""
+    if not table:
+        return
+    try:
+        ts = _now_iso()
+        table.put_item(Item={
+            "pk": f"SUBMISSION#{submission_id}",
+            "sk": f"AUDIT#{ts}",
+            "submissionId": submission_id,
+            "timestamp": ts,
+            "actor": actor,
+            "action": action,
+            "details": details,
+        })
+    except Exception:  # noqa: BLE001
+        # Audit is best-effort; don't fail the user's request if the log write errors.
+        pass
+
+
+# ── Single-table helpers ───────────────────────────────────
+
+def _sub_key(submission_id: str) -> dict[str, str]:
+    return {"pk": f"SUBMISSION#{submission_id}", "sk": "META"}
+
+
+def _get_submission(submission_id: str) -> dict[str, Any] | None:
+    if not table:
+        return None
+    return table.get_item(Key=_sub_key(submission_id)).get("Item")
+
+
+def _put_submission(item: dict[str, Any]) -> None:
+    """Write a submission record. Attaches pk/sk/gsi1 keys from submissionId."""
+    if not table:
+        return
+    sid = item["submissionId"]
+    item = {
+        **item,
+        "pk": f"SUBMISSION#{sid}",
+        "sk": "META",
+        "gsi1pk": "SUBMISSION_LIST",
+        "gsi1sk": item.get("submittedAt") or _now_iso(),
+    }
+    table.put_item(Item=item)
+
+
+def _list_submissions() -> list[dict[str, Any]]:
+    """Query the listIx GSI to return all submissions, newest first."""
+    if not table:
+        return []
+    resp = table.query(
+        IndexName="listIx",
+        KeyConditionExpression="gsi1pk = :p",
+        ExpressionAttributeValues={":p": "SUBMISSION_LIST"},
+        ScanIndexForward=False,
+    )
+    return resp.get("Items", [])
+
+
+def _list_audit(submission_id: str) -> list[dict[str, Any]]:
+    if not table:
+        return []
+    resp = table.query(
+        KeyConditionExpression="pk = :p AND begins_with(sk, :s)",
+        ExpressionAttributeValues={":p": f"SUBMISSION#{submission_id}", ":s": "AUDIT#"},
+        ScanIndexForward=False,
+    )
+    return resp.get("Items", [])
+
+
+def _delete_submission_data(submission_id: str) -> None:
+    """Delete the META row and all audit rows for a submission."""
+    if not table:
+        return
+    # Query all items under this submission's partition
+    resp = table.query(
+        KeyConditionExpression="pk = :p",
+        ExpressionAttributeValues={":p": f"SUBMISSION#{submission_id}"},
+    )
+    with table.batch_writer() as batch:
+        for it in resp.get("Items", []):
+            batch.delete_item(Key={"pk": it["pk"], "sk": it["sk"]})
+
+
 def lambda_handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
     headers = _cors_headers(event)
 
@@ -159,6 +250,8 @@ def lambda_handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
     method = event.get("httpMethod", "")
     if resource.startswith("/admin/"):
         return _handle_admin(event, headers)
+    if resource == "/audit/{submissionId}" and method == "GET":
+        return _handle_audit(event, headers)
     if resource == "/package" and method == "GET":
         return _handle_package(event, headers)
     if resource == "/status" and method == "GET":
@@ -241,7 +334,7 @@ def _handle_status(event: dict[str, Any], headers: dict[str, str]) -> dict[str, 
     dept_keys, is_super = _auth(event)
     if table:
         submissions = []
-        for item in _scan_all(table):
+        for item in _list_submissions():
             refund_types = [t.strip() for t in item.get("refundType", "").split(",") if t.strip()]
             depts = item.get("departments") or _derive_departments(refund_types)
             if not is_super and not (dept_keys & set(depts)):
@@ -289,8 +382,7 @@ def _handle_upload_complete(event: dict[str, Any], headers: dict[str, str]) -> d
         return _err(500, "DynamoDB not configured", headers)
 
     # Get the item to read refundType
-    resp = table.get_item(Key={"submissionId": submission_id})
-    item = resp.get("Item")
+    item = _get_submission(submission_id)
     if not item:
         return _err(404, "Submission not found", headers)
 
@@ -298,7 +390,7 @@ def _handle_upload_complete(event: dict[str, Any], headers: dict[str, str]) -> d
     status = _classify_status(refund_types, filenames)
 
     table.update_item(
-        Key={"submissionId": submission_id},
+        Key=_sub_key(submission_id),
         UpdateExpression="SET #s = :s, documents = :d, updatedAt = :u",
         ExpressionAttributeNames={"#s": "status"},
         ExpressionAttributeValues={
@@ -337,10 +429,10 @@ def _handle_update_status(event: dict[str, Any], headers: dict[str, str]) -> dic
     if not table:
         return _err(500, "DynamoDB not configured", headers)
 
-    resp = table.get_item(Key={"submissionId": submission_id})
-    item = resp.get("Item")
-    if not item:
+    resp_item = _get_submission(submission_id)
+    if not resp_item:
         return _err(404, "Submission not found", headers)
+    item = resp_item
 
     dept_keys, is_super = _auth(event)
     submission_depts = set(item.get("departments") or _derive_departments(
@@ -348,12 +440,15 @@ def _handle_update_status(event: dict[str, Any], headers: dict[str, str]) -> dic
     if not is_super and not (dept_keys & submission_depts):
         return _err(403, "Not authorized for this submission", headers)
 
+    prev_status = item.get("status", "")
     table.update_item(
-        Key={"submissionId": submission_id},
+        Key=_sub_key(submission_id),
         UpdateExpression="SET #s = :s, updatedAt = :u",
         ExpressionAttributeNames={"#s": "status"},
         ExpressionAttributeValues={":s": new_status, ":u": _now_iso()},
     )
+    _audit(submission_id, _actor(event), "status_change",
+           {"from": prev_status, "to": new_status})
 
     return {
         "statusCode": 200,
@@ -390,15 +485,41 @@ def _handle_delete_submission(event: dict[str, Any], headers: dict[str, str]) ->
         for i in range(0, len(keys), 1000):
             s3.delete_objects(Bucket=BUCKET, Delete={"Objects": keys[i:i + 1000]})
 
-    # Delete from DynamoDB
+    # Delete from DynamoDB (META row + all audit rows under this submission)
     if table:
-        table.delete_item(Key={"submissionId": submission_id})
+        _delete_submission_data(submission_id)
+    # Note: delete wipes the whole partition, so there's no useful place to
+    # write a final "deleted by X" audit row that would survive. If forensics
+    # are needed, consult CloudWatch Lambda logs instead.
 
     return {
         "statusCode": 200,
         "headers": headers,
         "body": json.dumps({"submissionId": submission_id, "deleted": True}),
     }
+
+
+def _handle_audit(event: dict[str, Any], headers: dict[str, str]) -> dict[str, Any]:
+    """Return audit entries for a submission, scoped by caller permissions."""
+    submission_id = ((event.get("pathParameters") or {}).get("submissionId") or "").strip()
+    if not re.fullmatch(r'[0-9a-f]{12}', submission_id):
+        return _err(400, "Invalid submission id", headers)
+    if not table:
+        return _err(500, "Audit backend not configured", headers)
+
+    item = _get_submission(submission_id)
+    if not item:
+        return _err(404, "Submission not found", headers)
+
+    dept_keys, is_super = _auth(event)
+    submission_depts = set(item.get("departments") or _derive_departments(
+        [t.strip() for t in item.get("refundType", "").split(",") if t.strip()]))
+    if not is_super and not (dept_keys & submission_depts):
+        return _err(403, "Not authorized for this submission", headers)
+
+    entries = _list_audit(submission_id)
+    return {"statusCode": 200, "headers": headers,
+            "body": json.dumps({"submissionId": submission_id, "entries": entries})}
 
 
 def _handle_upload(event: dict[str, Any], headers: dict[str, str]) -> dict[str, Any]:
@@ -444,7 +565,7 @@ def _handle_upload(event: dict[str, Any], headers: dict[str, str]) -> dict[str, 
     # Write initial record to DynamoDB
     if table:
         refund_types = [t.strip() for t in refund_type.split(",") if t.strip()]
-        table.put_item(Item={
+        _put_submission({
             "submissionId": submission_id,
             "name": name,
             "refundType": refund_type,

--- a/config.yaml
+++ b/config.yaml
@@ -28,7 +28,7 @@ super_admin:
   email: CHANGEME@example.com
 
 notifications:
-  mode: log         # "log" (CloudWatch only) or "ses"
+  mode: ses         # "ses" (real email) or "log" (CloudWatch only)
   # REQUIRED if mode is "ses". This is the "From" address on notification
   # emails. CDK creates an SES identity; you must click the verification
   # link AWS sends before notifications can actually deliver.


### PR DESCRIPTION
Closes #4 
Closes #5 

Adds email notifications to division admins on new submissions and documents-uploaded transitions, plus a full audit trail of status changes visible in the submission detail dialog.

Depends on #8 (merged, admin-dashboard-foundation).