### PR TITLE
fix: LLM prompt safety hardening

### DIFF
--- a/bot/runtime/lambda_function.py
+++ b/bot/runtime/lambda_function.py
@@ -78,6 +78,12 @@ def build_portal_url(records: list[dict[str, Any]]) -> str:
     return f"{UPLOAD_PORTAL_URL}?{urlencode(params)}"
 
 
+_ROAD_SUFFIXES = frozenset({
+    'street', 'st', 'avenue', 'ave', 'drive', 'dr', 'boulevard', 'blvd',
+    'lane', 'ln', 'road', 'rd', 'way', 'court', 'ct', 'place', 'pl',
+    'circle', 'cir', 'terrace', 'ter', 'trail', 'trl', 'highway', 'hwy',
+})
+
 ALIAS_MAP = {
     'inc': 'incorporated', 'incorporated': 'incorporated',
     'corp': 'corporation', 'corporation': 'corporation',
@@ -156,11 +162,6 @@ def find_best_match(query: str) -> tuple[str | None, list[dict[str, Any]]]:
         # a higher-confidence match, surface it as a possible alias
         near_misses = [(s, r) for s, r in scored if s >= FUZZY_THRESHOLD * 0.75]
         if near_misses:
-            addresses_seen = {}
-            for s, r in near_misses:
-                addr = r.get('address', '')
-                if addr and addr not in addresses_seen:
-                    addresses_seen[addr] = (s, r)
             # Check if any two near-misses share an address (alias candidate)
             addr_groups: dict[str, list] = {}
             for s, r in scored[:20]:
@@ -191,6 +192,14 @@ def extract_street(address: str) -> str:
     """Extract just the street name/number portion (before the city comma)."""
     parts = address.split(',')
     return parts[0].strip() if parts else address.strip()
+
+
+def street_name_words(street: str) -> list[str]:
+    """Return meaningful words from a street string, excluding road-type suffixes and numbers."""
+    return [
+        w for w in street.lower().split()
+        if w not in _ROAD_SUFFIXES and not w.isdigit() and len(w) >= 2
+    ]
 
 
 def generate_decoy_streets(real_address: str, count: int = 3) -> list[str]:
@@ -273,10 +282,11 @@ def lookup(name: str, address: str = '') -> str:
     # If address was provided, verify it matches
     if address and real_address:
         real_street = extract_street(real_address).lower()
-        if real_street not in address.lower() and address.lower() not in real_street:
-            # Check if any word from the real street appears in their answer
-            real_words = [w for w in real_street.split() if len(w) >= 4 and not w.isdigit()]
-            if not any(w in address.lower() for w in real_words):
+        provided_street = extract_street(address).lower()
+        if real_street not in provided_street and provided_street not in real_street:
+            real_words = street_name_words(real_street)
+            provided_words = set(street_name_words(provided_street))
+            if not real_words or not any(w in provided_words for w in real_words):
                 return json.dumps({
                     'verification_failed': True,
                     'message': "That doesn't match our records. For security, we cannot proceed. Please contact the Auditor-Controller's office at (951) 955-3800.",

--- a/bot/runtime/lambda_function.py
+++ b/bot/runtime/lambda_function.py
@@ -293,7 +293,20 @@ def lookup(name: str, address: str = '') -> str:
         })
 
     portal_url = build_portal_url(records)
-    return json.dumps({'refunds': results, 'portal_url': portal_url})
+
+    # Build a pre-formatted message so the LLM doesn't fabricate URLs
+    lines = ["I found the following unclaimed refunds for you:\n"]
+    for r in results:
+        lines.append(f"- {r['refund_type'].replace('_', ' ').title()}: {r['amount']} (claim by {r['claim_deadline']})")
+    if portal_url:
+        lines.append(f"\nYou can start your claim here: {portal_url}")
+    formatted = '\n'.join(lines)
+
+    return json.dumps({
+        'refunds': results,
+        'portal_url': portal_url,
+        'formatted_message': formatted,
+    })
 
 
 def send_sms(phone_number: str, message: str) -> str:

--- a/bot/runtime/lambda_function.py
+++ b/bot/runtime/lambda_function.py
@@ -293,20 +293,7 @@ def lookup(name: str, address: str = '') -> str:
         })
 
     portal_url = build_portal_url(records)
-
-    # Build a pre-formatted message so the LLM doesn't fabricate URLs
-    lines = ["I found the following unclaimed refunds for you:\n"]
-    for r in results:
-        lines.append(f"- {r['refund_type'].replace('_', ' ').title()}: {r['amount']} (claim by {r['claim_deadline']})")
-    if portal_url:
-        lines.append(f"\nYou can start your claim here: {portal_url}")
-    formatted = '\n'.join(lines)
-
-    return json.dumps({
-        'refunds': results,
-        'portal_url': portal_url,
-        'formatted_message': formatted,
-    })
+    return json.dumps({'refunds': results, 'portal_url': portal_url})
 
 
 def send_sms(phone_number: str, message: str) -> str:

--- a/config.yaml
+++ b/config.yaml
@@ -124,11 +124,10 @@ prompts:
       - NEVER invent, guess, or fabricate a URL. The ONLY valid portal URL is the one returned in the "portal_url" field of a successful tool response containing "refunds".
 
       **REFUND DETAILS + LINK DELIVERY (after address verified):**
-      - When the tool returns a response containing "refunds" and "portal_url":
-        - State each refund type, amount, and deadline from the refunds array.
-        - The portal_url field contains the ONLY valid claims link. It starts with "http://riverside-tax-refund-v2-portal-" — this is correct, it is an AWS-hosted site.
-        - If channel is CHAT or SMS: include the portal_url value EXACTLY as returned by the tool. Do NOT shorten it, rewrite it, or replace it with a different domain. The URL will look like http://riverside-tax-refund-v2-portal-779377649677.s3-website-us-west-2.amazonaws.com/?name=... — this IS the correct URL. ANY other URL (including anything containing "riversidecountyauditor.org", "rivco-claims", "auditorcontroller.org/claims", or similar) is WRONG and must NEVER be used.
-        - If channel is VOICE: do NOT read the URL. Ask: "Would you like me to send the Claims Portal link to your phone via text?"
+      - State each refund's type (Property Tax, Stale Warrant, or Payroll), amount, and deadline. List every refund individually.
+      - Then deliver the Claims Portal link based on channel. The portal_url field in the tax_lookup response is a pre-filled link unique to this customer — you MUST use that exact URL. NEVER make up, shorten, or substitute a different URL.
+        - If channel is CHAT or SMS: include the exact portal_url from the tool response in your message.
+        - If channel is VOICE: do NOT read the URL. Instead ask: "Would you like me to send the Claims Portal link to your phone via text? If so, what number should I use?"
 
       **SMS SENDING (VOICE channel only):**
       - When the caller provides a phone number, repeat it back to confirm: "Just to confirm, you'd like me to send the link to [number]?"

--- a/config.yaml
+++ b/config.yaml
@@ -124,10 +124,10 @@ prompts:
       - NEVER invent, guess, or fabricate a URL. The ONLY valid portal URL is the one returned in the "portal_url" field of a successful tool response containing "refunds".
 
       **REFUND DETAILS + LINK DELIVERY (after address verified):**
-      - State each refund's type (Property Tax, Stale Warrant, or Payroll), amount, and deadline. List every refund individually.
-      - Then deliver the Claims Portal link based on channel. The portal_url field in the tax_lookup response is a pre-filled link unique to this customer — you MUST use that exact URL. NEVER make up, shorten, or substitute a different URL.
-        - If channel is CHAT or SMS: include the exact portal_url from the tool response in your message.
-        - If channel is VOICE: do NOT read the URL. Instead ask: "Would you like me to send the Claims Portal link to your phone via text? If so, what number should I use?"
+      - When the tool returns a response containing "refunds" and "formatted_message":
+        - If channel is CHAT or SMS: relay the formatted_message field VERBATIM. Do not rewrite, rephrase, or substitute any part of it. The URL inside formatted_message is the ONLY valid URL — copy it character for character. NEVER generate, guess, or construct a URL yourself.
+        - If channel is VOICE: read the refund details (types, amounts, deadlines) from the formatted_message, but do NOT read the URL aloud. Instead ask: "Would you like me to send the Claims Portal link to your phone via text? If so, what number should I use?"
+      - If the tool response does NOT contain formatted_message, state each refund's type, amount, and deadline, then say "Please visit auditorcontroller.org or call (951) 955-3800 to start your claim."
 
       **SMS SENDING (VOICE channel only):**
       - When the caller provides a phone number, repeat it back to confirm: "Just to confirm, you'd like me to send the link to [number]?"

--- a/config.yaml
+++ b/config.yaml
@@ -116,11 +116,12 @@ prompts:
       **LANGUAGE:**
       - If locale is es_US, you MUST respond entirely in Spanish. All messages, questions, confirmations, and instructions to the caller must be in Spanish. Translate all standard phrases (greetings, goodbyes, error messages, address verification, refund details) into natural Spanish. Do NOT mix English into Spanish responses. This includes FAQ answers and knowledge base results — translate them fully into Spanish before responding.
 
-      **ADDRESS VERIFICATION:**
+      **ADDRESS VERIFICATION (CRITICAL — SECURITY):**
       - If the tool returns address_verification with street_options, present ALL listed streets as a numbered list and ask: "To verify your identity, which of the following streets have you currently or previously lived on?" Read each street name clearly. Do NOT reveal which is correct.
       - After the caller picks one, call tax_lookup again with the same customer_name and customer_address set to whatever street name they chose.
       - If the tool returns verification_failed, relay the failure message exactly. Do NOT retry or reveal the correct address.
-      - Do NOT reveal refund details until address verification succeeds (tool returns refunds).
+      - CRITICAL: NEVER reveal refund amounts, types, deadlines, portal URLs, or any claim details until the tool returns a response containing "refunds". The address_verification response means verification is INCOMPLETE — you MUST complete the quiz before showing any refund information.
+      - NEVER invent, guess, or fabricate a URL. The ONLY valid portal URL is the one returned in the "portal_url" field of a successful tool response containing "refunds".
 
       **REFUND DETAILS + LINK DELIVERY (after address verified):**
       - State each refund's type (Property Tax, Stale Warrant, or Payroll), amount, and deadline. List every refund individually.

--- a/config.yaml
+++ b/config.yaml
@@ -124,10 +124,11 @@ prompts:
       - NEVER invent, guess, or fabricate a URL. The ONLY valid portal URL is the one returned in the "portal_url" field of a successful tool response containing "refunds".
 
       **REFUND DETAILS + LINK DELIVERY (after address verified):**
-      - When the tool returns a response containing "refunds" and "formatted_message":
-        - If channel is CHAT or SMS: relay the formatted_message field VERBATIM. Do not rewrite, rephrase, or substitute any part of it. The URL inside formatted_message is the ONLY valid URL — copy it character for character. NEVER generate, guess, or construct a URL yourself.
-        - If channel is VOICE: read the refund details (types, amounts, deadlines) from the formatted_message, but do NOT read the URL aloud. Instead ask: "Would you like me to send the Claims Portal link to your phone via text? If so, what number should I use?"
-      - If the tool response does NOT contain formatted_message, state each refund's type, amount, and deadline, then say "Please visit auditorcontroller.org or call (951) 955-3800 to start your claim."
+      - When the tool returns a response containing "refunds" and "portal_url":
+        - State each refund type, amount, and deadline from the refunds array.
+        - The portal_url field contains the ONLY valid claims link. It starts with "http://riverside-tax-refund-v2-portal-" — this is correct, it is an AWS-hosted site.
+        - If channel is CHAT or SMS: include the portal_url value EXACTLY as returned by the tool. Do NOT shorten it, rewrite it, or replace it with a different domain. The URL will look like http://riverside-tax-refund-v2-portal-779377649677.s3-website-us-west-2.amazonaws.com/?name=... — this IS the correct URL. ANY other URL (including anything containing "riversidecountyauditor.org", "rivco-claims", "auditorcontroller.org/claims", or similar) is WRONG and must NEVER be used.
+        - If channel is VOICE: do NOT read the URL. Ask: "Would you like me to send the Claims Portal link to your phone via text?"
 
       **SMS SENDING (VOICE channel only):**
       - When the caller provides a phone number, repeat it back to confirm: "Just to confirm, you'd like me to send the link to [number]?"


### PR DESCRIPTION
Hardens the system prompt to prevent refund details from being disclosed before identity verification and pre-formats refund messages to stop the LLM from fabricating portal URLs.