### PR TITLE
feat: security hardening — defense-in-depth on top of decoy quiz

### DIFF
--- a/bot/chat_handler/lambda_function.py
+++ b/bot/chat_handler/lambda_function.py
@@ -286,7 +286,7 @@ def _record_verification_success(customer_name: str) -> None:
 
 # ── Tool dispatch ──────────────────────────────────────────────
 
-def _tool_tax_lookup(session_id: str, input_: dict) -> str:
+def _tool_tax_lookup(_session_id: str, input_: dict) -> str:
     """Two-step verified lookup with per-name lockout after 5 failures."""
     customer_name = input_["customer_name"]
 

--- a/bot/chat_handler/lambda_function.py
+++ b/bot/chat_handler/lambda_function.py
@@ -35,6 +35,8 @@ TAX_LOOKUP_FN = os.environ["TAX_LOOKUP_FN"]
 WS_ENDPOINT = os.environ["WS_ENDPOINT"]
 SES_SENDER = os.environ.get("SES_SENDER", "")
 AI_PROMPT_PARAM = os.environ["AI_PROMPT_PARAM"]
+GUARDRAIL_ID = os.environ.get("GUARDRAIL_ID", "")
+GUARDRAIL_VERSION = os.environ.get("GUARDRAIL_VERSION", "")
 REGION = os.environ.get("AWS_REGION", "us-west-2")
 SESSION_TTL_DAYS = 7
 
@@ -64,9 +66,15 @@ TOOLS = [
     {
         "name": "tax_lookup",
         "description": (
-            "Look up tax refunds for a customer by name. Returns refunds (type, amount, deadline, "
-            "address) and a portal_url unique to that customer. If multiple people share the name, "
-            "returns disambiguation_needed with the list of addresses."
+            "Look up tax refunds for a customer. Two-step identity verification. "
+            "Step 1: pass customer_name only — returns address_verification:'street' "
+            "with a list of street_options to ask the user. "
+            "Step 2: after the user picks a street, pass customer_name + customer_street — "
+            "returns address_verification:'number' asking for the house number on that street. "
+            "Step 3: pass customer_name + customer_street + customer_number — returns refunds "
+            "and portal_url on success, or verification_failed on a wrong answer. The tool never "
+            "returns the actual address. After verification_failed, do NOT retry; tell the user "
+            "to contact the office."
         ),
         "input_schema": {
             "type": "object",
@@ -75,9 +83,13 @@ TOOLS = [
                     "type": "string",
                     "description": "Full name, first name, or business name to search for.",
                 },
-                "customer_address": {
+                "customer_street": {
                     "type": "string",
-                    "description": "Optional. Used to disambiguate when multiple people share the name.",
+                    "description": "The street name the user picked from the verification quiz (e.g. 'Mission Blvd'). Step 2+.",
+                },
+                "customer_number": {
+                    "type": "string",
+                    "description": "The house number the user provided (e.g. '789'). Step 3 only.",
                 },
             },
             "required": ["customer_name"],
@@ -210,18 +222,106 @@ def _create_handoff(session_id: str, reason: str) -> str:
     return ref
 
 
+# ── Verification lockout (per-session attempt counter) ─────────
+
+MAX_VERIFICATION_FAILURES = 5
+LOCKOUT_TTL_SECONDS = 60 * 60  # 1 hour
+
+
+def _is_locked(session_id: str) -> bool:
+    """Return True if this session has hit MAX_VERIFICATION_FAILURES recently."""
+    resp = table.get_item(Key={"pk": f"SESSION#{session_id}", "sk": "META"})
+    item = resp.get("Item") or {}
+    locked_until = int(item.get("verificationLockedUntil") or 0)
+    return locked_until > int(time.time())
+
+
+def _record_verification_failure(session_id: str) -> tuple[int, bool]:
+    """Increment failure counter; lock the session at MAX_VERIFICATION_FAILURES.
+
+    Returns `(failures_after_increment, is_now_locked)`.
+    """
+    now = int(time.time())
+    resp = table.update_item(
+        Key={"pk": f"SESSION#{session_id}", "sk": "META"},
+        UpdateExpression=(
+            "SET verificationFailures = if_not_exists(verificationFailures, :z) + :one, "
+            "lastFailureAt = :ts"
+        ),
+        ExpressionAttributeValues={":z": 0, ":one": 1, ":ts": _now_iso()},
+        ReturnValues="UPDATED_NEW",
+    )
+    failures = int(resp.get("Attributes", {}).get("verificationFailures", 0))
+    if failures >= MAX_VERIFICATION_FAILURES:
+        table.update_item(
+            Key={"pk": f"SESSION#{session_id}", "sk": "META"},
+            UpdateExpression="SET verificationLockedUntil = :u",
+            ExpressionAttributeValues={":u": now + LOCKOUT_TTL_SECONDS},
+        )
+        return failures, True
+    return failures, False
+
+
+def _record_verification_success(session_id: str) -> None:
+    """Reset failure counter on a clean verification."""
+    table.update_item(
+        Key={"pk": f"SESSION#{session_id}", "sk": "META"},
+        UpdateExpression="SET verificationFailures = :z REMOVE verificationLockedUntil",
+        ExpressionAttributeValues={":z": 0},
+    )
+
+
 # ── Tool dispatch ──────────────────────────────────────────────
 
-def _tool_tax_lookup(input_: dict) -> str:
+def _tool_tax_lookup(session_id: str, input_: dict) -> str:
+    """Two-step verified lookup with per-session lockout after 5 failures."""
+    if _is_locked(session_id):
+        return json.dumps({
+            "locked": True,
+            "message": (
+                "This conversation has been locked after too many failed verification "
+                "attempts. Please contact the Auditor-Controller's office at "
+                "(951) 955-3800 to continue."
+            ),
+        })
+
     payload = {"customer_name": input_["customer_name"]}
-    if input_.get("customer_address"):
-        payload["customer_address"] = input_["customer_address"]
+    if input_.get("customer_street"):
+        payload["customer_street"] = input_["customer_street"]
+    if input_.get("customer_number"):
+        payload["customer_number"] = input_["customer_number"]
     resp = lambda_client.invoke(
         FunctionName=TAX_LOOKUP_FN,
         Payload=json.dumps(payload).encode("utf-8"),
     )
     body = json.loads(resp["Payload"].read())
-    return body.get("result", "Lookup failed.")
+    result_str = body.get("result", json.dumps({"error": "Lookup failed."}))
+
+    # If the tool reported a verification failure and we're at the *attempt*
+    # boundary (street or number provided), count it. Don't count the initial
+    # quiz fetch (no street, no number) as an attempt.
+    try:
+        result = json.loads(result_str)
+    except (json.JSONDecodeError, TypeError):
+        return result_str
+
+    is_attempt = bool(input_.get("customer_street") or input_.get("customer_number"))
+    if is_attempt and result.get("verification_failed"):
+        failures, locked = _record_verification_failure(session_id)
+        result["attempts_remaining"] = max(0, MAX_VERIFICATION_FAILURES - failures)
+        if locked:
+            result["locked"] = True
+            result["message"] = (
+                "Too many failed verification attempts. This conversation is locked "
+                "for an hour. Please contact the Auditor-Controller's office at "
+                "(951) 955-3800 to continue."
+            )
+        return json.dumps(result)
+
+    if result.get("refunds"):
+        _record_verification_success(session_id)
+
+    return result_str
 
 
 def _tool_request_agent(session_id: str, input_: dict) -> str:
@@ -248,7 +348,7 @@ def _tool_send_email(input_: dict) -> str:
 
 def _dispatch_tool(session_id: str, name: str, input_: dict) -> str:
     if name == "tax_lookup":
-        return _tool_tax_lookup(input_)
+        return _tool_tax_lookup(session_id, input_)
     if name == "request_agent":
         return _tool_request_agent(session_id, input_)
     if name == "send_email":
@@ -335,12 +435,22 @@ def _stream_turn(connection_id: str, messages: list[dict]) -> tuple[list[dict], 
         "messages": messages,
     }
 
-    response = bedrock.invoke_model_with_response_stream(
-        modelId=MODEL_ID,
-        body=json.dumps(body),
-        contentType="application/json",
-        accept="application/json",
-    )
+    invoke_kwargs: dict = {
+        "modelId": MODEL_ID,
+        "body": json.dumps(body),
+        "contentType": "application/json",
+        "accept": "application/json",
+    }
+    # Bedrock applies the guardrail to both the input messages and the model
+    # output stream. Blocked content surfaces as a `BLOCKED` stop_reason and a
+    # synthesized assistant message in the stream — same handling as a normal
+    # turn, no extra branch needed here.
+    if GUARDRAIL_ID:
+        invoke_kwargs["guardrailIdentifier"] = GUARDRAIL_ID
+        if GUARDRAIL_VERSION:
+            invoke_kwargs["guardrailVersion"] = GUARDRAIL_VERSION
+
+    response = bedrock.invoke_model_with_response_stream(**invoke_kwargs)
 
     blocks: dict[int, dict] = {}
     tool_input_buffers: dict[int, str] = {}

--- a/bot/chat_handler/lambda_function.py
+++ b/bot/chat_handler/lambda_function.py
@@ -39,6 +39,7 @@ GUARDRAIL_ID = os.environ.get("GUARDRAIL_ID", "")
 GUARDRAIL_VERSION = os.environ.get("GUARDRAIL_VERSION", "")
 REGION = os.environ.get("AWS_REGION", "us-west-2")
 SESSION_TTL_DAYS = 7
+OFFICE_PHONE = os.environ.get("OFFICE_PHONE", "(951) 955-3800")
 
 ANTHROPIC_VERSION = "bedrock-2023-05-31"
 
@@ -222,50 +223,62 @@ def _create_handoff(session_id: str, reason: str) -> str:
     return ref
 
 
-# ── Verification lockout (per-session attempt counter) ─────────
+# ── Verification lockout (per-name attempt counter) ────────────
+# Keyed on a normalized version of the looked-up customer name so a new
+# session does not reset the counter.
 
 MAX_VERIFICATION_FAILURES = 5
 LOCKOUT_TTL_SECONDS = 60 * 60  # 1 hour
 
 
-def _is_locked(session_id: str) -> bool:
-    """Return True if this session has hit MAX_VERIFICATION_FAILURES recently."""
-    resp = table.get_item(Key={"pk": f"SESSION#{session_id}", "sk": "META"})
+def _lockout_pk(customer_name: str) -> str:
+    return f"LOCKOUT#{customer_name.lower().strip()}"
+
+
+def _is_locked(customer_name: str) -> bool:
+    resp = table.get_item(Key={"pk": _lockout_pk(customer_name), "sk": "META"})
     item = resp.get("Item") or {}
     locked_until = int(item.get("verificationLockedUntil") or 0)
     return locked_until > int(time.time())
 
 
-def _record_verification_failure(session_id: str) -> tuple[int, bool]:
-    """Increment failure counter; lock the session at MAX_VERIFICATION_FAILURES.
+def _record_verification_failure(customer_name: str) -> tuple[int, bool]:
+    """Atomically increment the failure counter; lock when the threshold is reached.
+
+    Uses ADD (atomic counter) for the increment so concurrent requests can't
+    double-count. The lock timestamp is set in a second conditional write that
+    is idempotent — concurrent callers racing to set it are both fine.
 
     Returns `(failures_after_increment, is_now_locked)`.
     """
     now = int(time.time())
     resp = table.update_item(
-        Key={"pk": f"SESSION#{session_id}", "sk": "META"},
-        UpdateExpression=(
-            "SET verificationFailures = if_not_exists(verificationFailures, :z) + :one, "
-            "lastFailureAt = :ts"
-        ),
-        ExpressionAttributeValues={":z": 0, ":one": 1, ":ts": _now_iso()},
+        Key={"pk": _lockout_pk(customer_name), "sk": "META"},
+        UpdateExpression="ADD verificationFailures :one SET lastFailureAt = :ts",
+        ExpressionAttributeValues={":one": 1, ":ts": _now_iso()},
         ReturnValues="UPDATED_NEW",
     )
     failures = int(resp.get("Attributes", {}).get("verificationFailures", 0))
-    if failures >= MAX_VERIFICATION_FAILURES:
-        table.update_item(
-            Key={"pk": f"SESSION#{session_id}", "sk": "META"},
-            UpdateExpression="SET verificationLockedUntil = :u",
-            ExpressionAttributeValues={":u": now + LOCKOUT_TTL_SECONDS},
-        )
-        return failures, True
-    return failures, False
+    is_locked = failures >= MAX_VERIFICATION_FAILURES
+    if is_locked:
+        try:
+            table.update_item(
+                Key={"pk": _lockout_pk(customer_name), "sk": "META"},
+                UpdateExpression="SET verificationLockedUntil = :u",
+                ConditionExpression=(
+                    "attribute_not_exists(verificationLockedUntil) OR verificationLockedUntil <= :now"
+                ),
+                ExpressionAttributeValues={":u": now + LOCKOUT_TTL_SECONDS, ":now": now},
+            )
+        except dynamodb.meta.client.exceptions.ConditionalCheckFailedException:
+            pass  # already locked by a concurrent request — fine
+    return failures, is_locked
 
 
-def _record_verification_success(session_id: str) -> None:
+def _record_verification_success(customer_name: str) -> None:
     """Reset failure counter on a clean verification."""
     table.update_item(
-        Key={"pk": f"SESSION#{session_id}", "sk": "META"},
+        Key={"pk": _lockout_pk(customer_name), "sk": "META"},
         UpdateExpression="SET verificationFailures = :z REMOVE verificationLockedUntil",
         ExpressionAttributeValues={":z": 0},
     )
@@ -274,18 +287,20 @@ def _record_verification_success(session_id: str) -> None:
 # ── Tool dispatch ──────────────────────────────────────────────
 
 def _tool_tax_lookup(session_id: str, input_: dict) -> str:
-    """Two-step verified lookup with per-session lockout after 5 failures."""
-    if _is_locked(session_id):
+    """Two-step verified lookup with per-name lockout after 5 failures."""
+    customer_name = input_["customer_name"]
+
+    if _is_locked(customer_name):
         return json.dumps({
             "locked": True,
             "message": (
-                "This conversation has been locked after too many failed verification "
-                "attempts. Please contact the Auditor-Controller's office at "
-                "(951) 955-3800 to continue."
+                "This lookup has been locked after too many failed verification "
+                f"attempts. Please contact the Auditor-Controller's office at "
+                f"{OFFICE_PHONE} to continue."
             ),
         })
 
-    payload = {"customer_name": input_["customer_name"]}
+    payload = {"customer_name": customer_name}
     if input_.get("customer_street"):
         payload["customer_street"] = input_["customer_street"]
     if input_.get("customer_number"):
@@ -297,9 +312,8 @@ def _tool_tax_lookup(session_id: str, input_: dict) -> str:
     body = json.loads(resp["Payload"].read())
     result_str = body.get("result", json.dumps({"error": "Lookup failed."}))
 
-    # If the tool reported a verification failure and we're at the *attempt*
-    # boundary (street or number provided), count it. Don't count the initial
-    # quiz fetch (no street, no number) as an attempt.
+    # Count a failure only when an answer was actually provided (street or number).
+    # The initial name-only call that returns the quiz does not count.
     try:
         result = json.loads(result_str)
     except (json.JSONDecodeError, TypeError):
@@ -307,19 +321,19 @@ def _tool_tax_lookup(session_id: str, input_: dict) -> str:
 
     is_attempt = bool(input_.get("customer_street") or input_.get("customer_number"))
     if is_attempt and result.get("verification_failed"):
-        failures, locked = _record_verification_failure(session_id)
+        failures, locked = _record_verification_failure(customer_name)
         result["attempts_remaining"] = max(0, MAX_VERIFICATION_FAILURES - failures)
         if locked:
             result["locked"] = True
             result["message"] = (
-                "Too many failed verification attempts. This conversation is locked "
-                "for an hour. Please contact the Auditor-Controller's office at "
-                "(951) 955-3800 to continue."
+                "Too many failed verification attempts. Further lookups for this name "
+                f"are locked for an hour. Please contact the Auditor-Controller's office at "
+                f"{OFFICE_PHONE} to continue."
             )
         return json.dumps(result)
 
     if result.get("refunds"):
-        _record_verification_success(session_id)
+        _record_verification_success(customer_name)
 
     return result_str
 

--- a/bot/infrastructure.py
+++ b/bot/infrastructure.py
@@ -16,6 +16,7 @@ from aws_cdk import (
     aws_apigateway as apigw,
     aws_apigatewayv2 as apigwv2,
     aws_apigatewayv2_integrations as apigwv2_int,
+    aws_bedrock as bedrock,
     aws_dynamodb as dynamodb,
     aws_cognito as cognito,
     aws_codebuild as codebuild,
@@ -164,6 +165,39 @@ class RiversideTaxRefundStack(Stack):
             tier=ssm.ParameterTier.ADVANCED,
         )
 
+        # ── Bedrock Guardrail (deny prompt-injection / harmful prompts) ──
+        # Applied on every chat handler invocation. Default deny on prompt
+        # attacks + the four harm categories. Cheap (~$0.15/1k checks).
+        guardrail = bedrock.CfnGuardrail(
+            self, "ChatGuardrail",
+            name=f"{proj}-chat-guardrail",
+            blocked_input_messaging=(
+                "I can't help with that request. If you're trying to look up a "
+                "refund or get information about an Auditor-Controller service, "
+                "let me know and I'll help."
+            ),
+            blocked_outputs_messaging=(
+                "I can't share that. If you have a question about a refund or "
+                "Auditor-Controller service, please let me know."
+            ),
+            content_policy_config=bedrock.CfnGuardrail.ContentPolicyConfigProperty(
+                filters_config=[
+                    bedrock.CfnGuardrail.ContentFilterConfigProperty(
+                        type=t, input_strength="HIGH", output_strength="HIGH"
+                    ) for t in ("SEXUAL", "VIOLENCE", "HATE", "INSULTS", "MISCONDUCT")
+                ] + [
+                    # PROMPT_ATTACK only supports input filtering
+                    bedrock.CfnGuardrail.ContentFilterConfigProperty(
+                        type="PROMPT_ATTACK", input_strength="HIGH", output_strength="NONE"
+                    ),
+                ],
+            ),
+        )
+        guardrail_version = bedrock.CfnGuardrailVersion(
+            self, "ChatGuardrailVersion",
+            guardrail_identifier=guardrail.attr_guardrail_id,
+        )
+
         # ── Chat handler Lambda (Bedrock Claude + WebSocket streaming) ──
         chat_fn = _lambda.Function(
             self, "ChatHandler",
@@ -185,6 +219,8 @@ class RiversideTaxRefundStack(Stack):
                 "TAX_LOOKUP_FN": fn.function_name,
                 "AI_PROMPT_PARAM": prompt_param.parameter_name,
                 "SES_SENDER": (cfg.get("notifications") or {}).get("sender", ""),
+                "GUARDRAIL_ID": guardrail.attr_guardrail_id,
+                "GUARDRAIL_VERSION": guardrail_version.attr_version,
             },
         )
         chat_table.grant_read_write_data(chat_fn)
@@ -194,6 +230,10 @@ class RiversideTaxRefundStack(Stack):
             actions=["bedrock:InvokeModel", "bedrock:InvokeModelWithResponseStream"],
             resources=[f"arn:aws:bedrock:*::foundation-model/*",
                        f"arn:aws:bedrock:*:{self.account}:inference-profile/*"],
+        ))
+        chat_fn.add_to_role_policy(iam.PolicyStatement(
+            actions=["bedrock:ApplyGuardrail"],
+            resources=[guardrail.attr_guardrail_arn],
         ))
         chat_fn.add_to_role_policy(iam.PolicyStatement(
             actions=["ses:SendEmail", "ses:SendRawEmail"],

--- a/bot/runtime/lambda_function.py
+++ b/bot/runtime/lambda_function.py
@@ -203,6 +203,51 @@ def street_name_words(street: str) -> list[str]:
     ]
 
 
+def split_street_parts(street: str) -> tuple[str, str]:
+    """Split '789 MISSION BLVD' into ('789', 'MISSION BLVD'). Number may be empty."""
+    parts = street.strip().split(None, 1)
+    if not parts:
+        return ('', '')
+    if parts[0].replace('-', '').isdigit() or _looks_like_house_num(parts[0]):
+        number = parts[0]
+        rest = parts[1] if len(parts) > 1 else ''
+        return (number, rest)
+    return ('', street.strip())
+
+
+def _looks_like_house_num(token: str) -> bool:
+    """Some addresses use forms like '4080A' or '23-19'. Permit alphanumeric leads with a digit."""
+    if not token:
+        return False
+    return any(c.isdigit() for c in token) and len(token) <= 8
+
+
+def street_name_only(address: str) -> str:
+    """Return the street part with any leading house number stripped.
+
+    >>> street_name_only('789 MISSION BLVD, San Diego, CA 92154')
+    'MISSION BLVD'
+    """
+    _, name = split_street_parts(extract_street(address))
+    return name.strip()
+
+
+_CONTROL_BYTES = re.compile(r'[\x00-\x1f\x7f-\x9f]')
+
+
+def sanitize_input(value: str, max_len: int = 200) -> str:
+    """Strip control bytes, collapse whitespace, truncate.
+
+    Mitigates injection via Unicode controls / null bytes / oversized inputs
+    before the value reaches the fuzzy matcher or downstream tools.
+    """
+    if not isinstance(value, str):
+        return ''
+    cleaned = _CONTROL_BYTES.sub('', value)
+    cleaned = ' '.join(cleaned.split())  # collapse whitespace runs
+    return cleaned[:max_len]
+
+
 def generate_decoy_streets(real_address: str, count: int = 3) -> list[str]:
     """Pick decoy street names from other records, preferring same city/state."""
     records = load_records()
@@ -231,67 +276,140 @@ def generate_decoy_streets(real_address: str, count: int = 3) -> list[str]:
     return decoys[:count]
 
 
-def lookup(name: str, address: str = '') -> str:
+def _street_matches(claim_street_name: str, real_address: str) -> bool:
+    """Compare claimant's street-name guess against the real street name (no number).
+
+    Both sides are normalized: lower-cased, leading house number stripped.
+    Tolerates partial matches (e.g. "Mission" vs "Mission Blvd").
+    """
+    claim = (claim_street_name or '').lower().strip()
+    if not claim:
+        return False
+    real_name = street_name_only(real_address).lower().strip()
+    if not real_name:
+        return False
+    if claim == real_name:
+        return True
+    # Word-overlap tolerance — handle "mission blvd" vs "mission boulevard"
+    real_words = [w for w in real_name.split() if len(w) >= 4 and not w.isdigit()]
+    return any(w in claim or claim in w for w in real_words)
+
+
+def _number_matches(claim_number: str, real_address: str) -> bool:
+    """Compare claimant's house-number guess against the real number."""
+    claim = (claim_number or '').strip()
+    if not claim:
+        return False
+    real_num, _ = split_street_parts(extract_street(real_address))
+    if not real_num:
+        return False
+    return claim.lower().replace('-', '') == real_num.lower().replace('-', '')
+
+
+def lookup(name: str, street: str = '', number: str = '') -> str:
+    """Two-step verified refund lookup.
+
+    Verification flow:
+      step 1 (no street, no number): identity quiz with decoy street options
+      step 2 (street provided, no number): verify street matches, then ask for number
+      step 3 (street + number): verify both, return refunds without `address` field
+
+    Output never includes the real address. The caller (chat handler) is
+    expected to track failed-attempt counts per session and stop calling
+    once locked.
+    """
+    name = sanitize_input(name)
+    street = sanitize_input(street, max_len=80)
+    number = sanitize_input(number, max_len=20)
+
     best_name, records = find_best_match(name)
     if not best_name:
-        return (
-            f"We found no refunds for {name}. "
-            "You may have no refunds or your refund may have passed its claim deadline."
-        )
-
-    addresses = sorted(set(r.get('address', '') for r in records))
-    if len(addresses) > 1:
-        if not address:
-            # Present truncated street names only (no full address for privacy)
-            street_options = [extract_street(a) for a in addresses]
-            return json.dumps({
-                'disambiguation_needed': True,
-                'name': best_name,
-                'addresses': street_options,
-                'message': f"We found multiple people named {best_name}. Which street have you lived on?",
-            })
-        addr_lower = address.lower().strip()
-        selected = next((a for a in addresses if addr_lower in a.lower()), None)
-        if not selected:
-            selected = next((a for a in addresses if any(w in addr_lower for w in a.lower().split() if len(w) >= 4)), None)
-        if selected:
-            records = [r for r in records if r.get('address', '') == selected]
-        else:
-            street_options = [extract_street(a) for a in addresses]
-            return json.dumps({
-                'disambiguation_needed': True,
-                'name': best_name,
-                'addresses': street_options,
-                'message': f"That didn't match our records for {best_name}. Which of these streets is yours?",
-            })
-
-    # Address quiz: present the real street + decoys, ask user to identify theirs
-    real_address = records[0].get('address', '')
-    if real_address and not address:
-        real_street = extract_street(real_address)
-        decoys = generate_decoy_streets(real_address, count=3)
-        options = [real_street] + decoys
-        random.shuffle(options)
         return json.dumps({
-            'address_verification': True,
-            'name': best_name,
-            'street_options': options,
-            'message': f"To verify your identity, which of the following streets have you lived on?",
+            'no_match': True,
+            'message': (
+                f"We found no refunds for {name}. "
+                "You may have no refunds, or your refund may have passed its claim deadline."
+            ),
         })
 
-    # If address was provided, verify it matches
-    if address and real_address:
-        real_street = extract_street(real_address).lower()
-        provided_street = extract_street(address).lower()
-        if real_street not in provided_street and provided_street not in real_street:
-            real_words = street_name_words(real_street)
-            provided_words = set(street_name_words(provided_street))
-            if not real_words or not any(w in provided_words for w in real_words):
-                return json.dumps({
-                    'verification_failed': True,
-                    'message': "That doesn't match our records. For security, we cannot proceed. Please contact the Auditor-Controller's office at (951) 955-3800.",
-                })
+    addresses = sorted(set(r.get('address', '') for r in records))
 
+    # Disambiguation when multiple records share the name (different addresses).
+    if len(addresses) > 1 and not street:
+        street_options = [street_name_only(a) for a in addresses]
+        return json.dumps({
+            'disambiguation_needed': True,
+            'name': best_name,
+            'street_options': street_options,
+            'message': f"We found multiple people named {best_name}. Which street have you lived on?",
+        })
+
+    # Filter to the matching record(s) once we have a street hint.
+    if len(addresses) > 1 and street:
+        matches = [r for r in records if _street_matches(street, r.get('address', ''))]
+        if not matches:
+            return json.dumps({
+                'verification_failed': True,
+                'message': (
+                    "That doesn't match our records. For security, we cannot proceed. "
+                    "Please contact the Auditor-Controller's office at (951) 955-3800."
+                ),
+            })
+        records = matches
+
+    real_address = records[0].get('address', '')
+    if not real_address:
+        return json.dumps({
+            'verification_failed': True,
+            'message': "We can't verify identity for this record. Please contact the office.",
+        })
+
+    # Step 1 — present the decoy quiz, ask which street.
+    if not street:
+        real_street_name = street_name_only(real_address)
+        decoy_addrs = generate_decoy_streets(real_address, count=3)
+        options = [real_street_name] + [street_name_only(a) for a in decoy_addrs]
+        random.shuffle(options)
+        return json.dumps({
+            'address_verification': 'street',
+            'name': best_name,
+            'street_options': options,
+            'message': "To verify your identity, which of the following streets have you currently or previously lived on?",
+        })
+
+    # Step 2 — street picked; verify it matches.
+    if not _street_matches(street, real_address):
+        return json.dumps({
+            'verification_failed': True,
+            'message': (
+                "That doesn't match our records. For security, we cannot proceed. "
+                "Please contact the Auditor-Controller's office at (951) 955-3800."
+            ),
+        })
+
+    # Step 2b — street ok, ask for the house number.
+    if not number:
+        return json.dumps({
+            'address_verification': 'number',
+            'name': best_name,
+            'street_picked': street_name_only(real_address),
+            'message': (
+                f"Thanks. To complete verification, what's the street number on "
+                f"{street_name_only(real_address)}?"
+            ),
+        })
+
+    # Step 3 — verify number too.
+    if not _number_matches(number, real_address):
+        return json.dumps({
+            'verification_failed': True,
+            'message': (
+                "That doesn't match our records. For security, we cannot proceed. "
+                "Please contact the Auditor-Controller's office at (951) 955-3800."
+            ),
+        })
+
+    # Verification passed — return refunds WITHOUT address.
     results = []
     for r in records:
         results.append({
@@ -299,21 +417,25 @@ def lookup(name: str, address: str = '') -> str:
             'refund_type': r['refund_type'],
             'amount': f"${r['amount']:,.2f}",
             'claim_deadline': r['claim_deadline'],
-            'address': r.get('address', ''),
         })
 
     portal_url = build_portal_url(records)
     return json.dumps({'refunds': results, 'portal_url': portal_url})
 
 
-def lambda_handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
-    """Sync invocation with `{customer_name, customer_address?}` payload."""
-    logger.info("Event: %s", json.dumps(event, default=str))
+def lambda_handler(event: dict[str, Any], _context: Any) -> dict[str, Any]:
+    """Sync invocation. Payload: `{customer_name, customer_street?, customer_number?}`.
+
+    Backwards-compat: a `customer_address` field maps to `customer_street`.
+    """
+    logger.info("Event: %s", json.dumps({k: v for k, v in event.items() if k != 'customer_number'}, default=str))
     try:
         name = (event.get('customer_name') or '').strip()
         if not name:
-            return {'result': 'customer_name is required'}
-        return {'result': lookup(name, event.get('customer_address', ''))}
+            return {'result': json.dumps({'error': 'customer_name is required'})}
+        street = (event.get('customer_street') or event.get('customer_address') or '').strip()
+        number = (event.get('customer_number') or '').strip()
+        return {'result': lookup(name, street, number)}
     except Exception:
         logger.exception("Unhandled error")
-        return {'result': 'An error occurred. Please try again.'}
+        return {'result': json.dumps({'error': 'An error occurred. Please try again.'})}

--- a/bot/upload_handler/lambda_function.py
+++ b/bot/upload_handler/lambda_function.py
@@ -26,7 +26,7 @@ ALLOWED_TYPES = {
     "application/json",
 }
 _SAFE_FILENAME = re.compile(r'[^\w.\-]')
-PACKAGE_EXPIRY = 7 * 24 * 3600  # 7 days
+PACKAGE_EXPIRY = 60 * 60  # 1 hour — short-lived; admin dashboard re-fetches on demand
 
 # Default document requirements per refund type. Used as the seed when the
 # admin-config table has no DOCREQ#<type> entry yet. Super-admin can override

--- a/config.yaml
+++ b/config.yaml
@@ -83,15 +83,32 @@ prompts:
     - If no refund found: "We found no refunds for [name]. You may have no refunds or your refund may have passed its claim deadline." Suggest checking the spelling or trying another name.
 
     **ADDRESS VERIFICATION (CRITICAL — SECURITY):**
-    - If the tool returns address_verification with street_options, present ALL listed streets as a numbered list and ask: "To verify your identity, which of the following streets have you currently or previously lived on?" Read each street name clearly. Do NOT reveal which is correct.
-    - After the user picks one, call tax_lookup again with the same customer_name and customer_address set to whatever street name they chose.
-    - If the tool returns verification_failed, relay the failure message exactly. Do NOT retry or reveal the correct address.
-    - CRITICAL: NEVER reveal refund amounts, types, deadlines, portal URLs, or any claim details until the tool returns a response containing "refunds". The address_verification response means verification is INCOMPLETE — you MUST complete the quiz before showing any refund information.
-    - NEVER invent, guess, or fabricate a URL. The ONLY valid portal URL is the one returned in the "portal_url" field of a successful tool response containing "refunds".
+    Two-step quiz. The tool drives it via the address_verification field.
+
+    Step 1 — When the tool returns `address_verification: "street"` with street_options:
+      - Present ALL listed streets as a numbered list. Ask: "To verify your identity, which of the following streets have you currently or previously lived on?"
+      - Do NOT reveal which is correct. Do NOT mention numbers, the verification process, or how this works.
+      - When the user picks one, call tax_lookup again with the same customer_name and customer_street set to the street they chose.
+
+    Step 2 — When the tool returns `address_verification: "number"`:
+      - Ask: "What's the street number on [street_picked]?"
+      - When the user answers, call tax_lookup again with customer_name + customer_street + customer_number.
+
+    Failures and lockout:
+      - If the tool returns `verification_failed`, relay the failure message exactly. Do NOT retry or reveal anything.
+      - If the tool returns `locked: true`, relay the locked message exactly. Do NOT call tax_lookup again in this conversation.
+      - The tool may include `attempts_remaining` after a failure — DO NOT mention this number to the user; it is for system bookkeeping only.
+
+    Critical rules:
+      - NEVER reveal refund amounts, types, deadlines, portal URLs, or any claim details until the tool returns a response containing "refunds". `address_verification` responses mean verification is INCOMPLETE — complete both steps before showing any refund information.
+      - NEVER invent, guess, or fabricate a URL. The ONLY valid portal URL is the one returned in the "portal_url" field of a successful tool response containing "refunds".
+      - The tool will never tell you the user's actual address. Don't try to deduce or repeat it.
 
     **REFUND DETAILS + LINK DELIVERY (after address verified):**
+    - First confirm verification briefly: open the message with "Identity verified ✓" so the user can see verification happened. Don't restate the address.
     - State each refund's type (Property Tax, Stale Warrant, or Payroll), amount, and deadline. List every refund individually.
     - Include the exact portal_url from the tax_lookup response in your message. The URL is unique to this customer — never modify, shorten, or substitute it.
+    - If the user later asks about the same refunds again in the same conversation (e.g., "I'd like to claim it"), remind them they're already verified before sharing the link again.
 
     **LIVE AGENT HANDOFF:**
     - If the user asks for a person, agent, representative, or is frustrated and a bot can't help, call the request_agent tool. The tool returns a reference number — relay it exactly as: "Your reference number is [REF]. Call (951) 955-3800 during office hours and give the agent that number — they'll pull up our conversation and continue from where we left off."


### PR DESCRIPTION
Adds a second verification step (house number after street pick), a per-session lockout after 5 failed attempts, input sanitization in the runtime Lambda, and a Bedrock guardrail on every chat invocation; also drops the admin download presigned URL TTL from 7 days to 1 hour.