### PR TITLE
fix: dedupe refund-type tags and friendlier filled-form labels

### DIFF
--- a/admin-dashboard/app/dashboard/page.tsx
+++ b/admin-dashboard/app/dashboard/page.tsx
@@ -220,7 +220,7 @@ export default function DashboardPage() {
                 <TableRow key={s.submissionId} className="cursor-pointer" onClick={() => setSelected(s)}>
                   <TableCell className="font-medium">{s.name}</TableCell>
                   <TableCell>
-                    {s.refundType.split(",").map((t) => (
+                    {Array.from(new Set(s.refundType.split(","))).map((t) => (
                       <Badge key={t} variant="secondary" className="mr-1">{labelFor(t, labels)}</Badge>
                     ))}
                   </TableCell>
@@ -306,7 +306,7 @@ function SubmissionDetail({ submission }: { submission: Submission }) {
         <aside className="flex flex-col gap-4 overflow-y-auto">
           <div>
             <p className="text-muted-foreground text-xs">ID: {submission.submissionId}</p>
-            <p className="text-muted-foreground text-xs">{submission.refundType}</p>
+            <p className="text-muted-foreground text-xs">{Array.from(new Set(submission.refundType.split(","))).join(", ")}</p>
           </div>
           <div>
             <p className="font-medium">Tasks</p>
@@ -336,7 +336,7 @@ function SubmissionDetail({ submission }: { submission: Submission }) {
                     onClick={() => setActive(f)}
                     className={`text-left w-full truncate ${active?.filename === f.filename ? "font-semibold text-foreground" : "text-blue-600 hover:underline"}`}
                   >
-                    📄 {f.filename}
+                    📄 {f.filename === "unified-form.json" ? "Filled claim form" : f.filename}
                   </button>
                 </li>
               ))}
@@ -393,7 +393,9 @@ function FileViewer({ file, submission }: { file: PackageFile; submission: Submi
     <div className="flex flex-col h-full">
       <div className="flex items-center justify-between border-b p-2 bg-background">
         <div className="flex items-center gap-2">
-          <span className="text-xs truncate">{file.filename}</span>
+          <span className="text-xs truncate">
+            {isUnifiedForm ? "Filled claim form" : file.filename}
+          </span>
           {isUnifiedForm && (
             <button
               onClick={() => setShowRaw(!showRaw)}
@@ -415,7 +417,7 @@ function FileViewer({ file, submission }: { file: PackageFile; submission: Submi
         {isUnifiedForm && !showRaw ? (
           <FilledFormViewer
             formDataUrl={file.downloadUrl}
-            refundTypes={submission.refundType.split(",")}
+            refundTypes={Array.from(new Set(submission.refundType.split(",")))}
           />
         ) : (
           <>

--- a/admin-dashboard/components/filled-form-viewer.tsx
+++ b/admin-dashboard/components/filled-form-viewer.tsx
@@ -10,6 +10,16 @@ type Props = {
 
 type RenderedItem = { type: string; url: string; label: string; signatureMissing?: boolean }
 
+const REFUND_TYPE_LABELS: Record<string, string> = {
+  STALE_WARRANT: "Stale Dated Warrant (AP-13)",
+  PAYROLL: "Payroll",
+  PROPERTY_TAX: "Property Tax",
+}
+
+function formatRefundType(rt: string): string {
+  return REFUND_TYPE_LABELS[rt] || rt.replace(/_/g, " ").toLowerCase().replace(/\b\w/g, (c) => c.toUpperCase())
+}
+
 export function FilledFormViewer({ formDataUrl, refundTypes }: Props) {
   const [pdfUrls, setPdfUrls] = useState<RenderedItem[]>([])
   const [active, setActive] = useState<string | null>(null)
@@ -40,7 +50,7 @@ export function FilledFormViewer({ formDataUrl, refundTypes }: Props) {
               results.push({
                 type: rt,
                 url: URL.createObjectURL(blob),
-                label: `${rt} (PDF overlay)`,
+                label: formatRefundType(rt),
                 signatureMissing: result.signatureMissing,
               })
             }
@@ -51,7 +61,7 @@ export function FilledFormViewer({ formDataUrl, refundTypes }: Props) {
               results.push({
                 type: rt,
                 url: URL.createObjectURL(blob),
-                label: `${rt} (Form view)`,
+                label: formatRefundType(rt),
               })
             }
           }


### PR DESCRIPTION
Fixes duplicate refund-type badges and filled-form tabs when a submission has multiple records of the same type, and renames the "unified-form.json" file label to "Filled claim form" in the dashboard.