### PR TITLE
feat: confidence scoring on tax_lookup → low-confidence flag in dashboard

### DIFF
--- a/admin-dashboard/app/dashboard/page.tsx
+++ b/admin-dashboard/app/dashboard/page.tsx
@@ -218,7 +218,20 @@ export default function DashboardPage() {
               const taskDone = allTasks.filter((t) => t.done).length
               return (
                 <TableRow key={s.submissionId} className="cursor-pointer" onClick={() => setSelected(s)}>
-                  <TableCell className="font-medium">{s.name}</TableCell>
+                  <TableCell className="font-medium">
+                    <div className="flex items-center gap-2">
+                      {s.name}
+                      {s.confidence === "low" && (
+                        <Badge
+                          variant="outline"
+                          className="bg-amber-50 text-amber-900 border-amber-300 text-[10px]"
+                          title="The bot matched this name with low confidence. Request extra verification documentation before approving."
+                        >
+                          ⚠ extra docs
+                        </Badge>
+                      )}
+                    </div>
+                  </TableCell>
                   <TableCell>
                     {Array.from(new Set(s.refundType.split(","))).map((t) => (
                       <Badge key={t} variant="secondary" className="mr-1">{labelFor(t, labels)}</Badge>
@@ -300,8 +313,28 @@ function SubmissionDetail({ submission }: { submission: Submission }) {
   return (
     <>
       <DialogHeader>
-        <DialogTitle>{submission.name}</DialogTitle>
+        <DialogTitle>
+          <div className="flex items-center gap-2">
+            {submission.name}
+            {submission.confidence === "low" && (
+              <Badge
+                variant="outline"
+                className="bg-amber-50 text-amber-900 border-amber-300 text-xs"
+              >
+                ⚠ low-confidence match
+              </Badge>
+            )}
+          </div>
+        </DialogTitle>
       </DialogHeader>
+      {submission.confidence === "low" && (
+        <div className="rounded-md border border-amber-300 bg-amber-50 p-3 text-xs text-amber-900">
+          <strong>Extra verification recommended.</strong> The bot's name match
+          for this claim was below the high-confidence threshold (likely an
+          alias, abbreviation, or near-miss). Request additional identity
+          documentation from the claimant before approving.
+        </div>
+      )}
       <div className="grid grid-cols-[260px_1fr] gap-4 text-sm flex-1 min-h-0">
         <aside className="flex flex-col gap-4 overflow-y-auto">
           <div>

--- a/admin-dashboard/lib/types.ts
+++ b/admin-dashboard/lib/types.ts
@@ -38,12 +38,15 @@ export type Task = { label: string; done: boolean }
 
 export type StatusValue = "partial" | "uploaded" | "under-review" | "approved" | "denied"
 
+export type Confidence = "high" | "low"
+
 export type Submission = {
   submissionId: string
   name: string
   refundType: string
   statuses: Record<string, StatusValue>
   documents: string[]
+  confidence: Confidence
   submittedAt: string
   departments: string[]
   tasksByDepartment: Record<string, Task[]>

--- a/bot/runtime/lambda_function.py
+++ b/bot/runtime/lambda_function.py
@@ -56,8 +56,13 @@ def build_claim_url(record: dict[str, Any]) -> str:
     return AP13_PDF_URL
 
 
-def build_portal_url(records: list[dict[str, Any]]) -> str:
-    """Build a single claims portal URL with all refund types and amounts."""
+def build_portal_url(records: list[dict[str, Any]], confidence: str = '') -> str:
+    """Build a single claims portal URL with all refund types and amounts.
+
+    `confidence` ('high'|'low') is propagated as a query param so the upload
+    portal stores it on the submission, and the admin dashboard can flag
+    low-confidence claims for extra-doc review.
+    """
     if not UPLOAD_PORTAL_URL:
         logger.warning("UPLOAD_PORTAL_URL not set — portal link will be empty")
         return ''
@@ -73,6 +78,8 @@ def build_portal_url(records: list[dict[str, Any]]) -> str:
         'address': records[0].get('address', ''),
         'id': identifiers,
     }
+    if confidence:
+        params['confidence'] = confidence
     pt = next((r for r in records if r['refund_type'] == 'PROPERTY_TAX'), None)
     if pt:
         params.update({k: pt[k] for k in ('assessment', 'taxyear') if k in pt})
@@ -141,9 +148,15 @@ def combined_score(query_norm: str, record_name_norm: str) -> float:
     return max(full_score, tok_score * 0.95)
 
 
-def find_best_match(query: str) -> tuple[str | None, list[dict[str, Any]]]:
+# Confidence bands. High = exact / alias hit at correct address. Low = match
+# above threshold but with name-level edits — admin should require extra docs.
+HIGH_CONFIDENCE_THRESHOLD = 0.95
+
+
+def find_best_match(query: str) -> tuple[str | None, list[dict[str, Any]], float]:
+    """Return (best_name, matching_records, score). Score is 0 if no match."""
     if not query:
-        return None, []
+        return None, [], 0.0
 
     q_norm = normalize_name(query)
     records = load_records()
@@ -180,13 +193,13 @@ def find_best_match(query: str) -> tuple[str | None, list[dict[str, Any]]]:
 
         if best_score < FUZZY_THRESHOLD:
             logger.info("Best score %.3f below threshold %.2f — no match", best_score, FUZZY_THRESHOLD)
-            return None, []
+            return None, [], best_score
 
     best_name = best_record['name']
     matching_records = [r for r in records if r['name'] == best_name]
     logger.info("Matched: '%s' (score=%.3f) | %d record(s)", best_name, best_score, len(matching_records))
 
-    return best_name, matching_records
+    return best_name, matching_records, best_score
 
 
 def extract_street(address: str) -> str:
@@ -322,7 +335,7 @@ def lookup(name: str, street: str = '', number: str = '') -> str:
     street = sanitize_input(street, max_len=80)
     number = sanitize_input(number, max_len=20)
 
-    best_name, records = find_best_match(name)
+    best_name, records, score = find_best_match(name)
     if not best_name:
         return json.dumps({
             'no_match': True,
@@ -419,8 +432,17 @@ def lookup(name: str, street: str = '', number: str = '') -> str:
             'claim_deadline': r['claim_deadline'],
         })
 
-    portal_url = build_portal_url(records)
-    return json.dumps({'refunds': results, 'portal_url': portal_url})
+    # `confidence` reflects the name-match strength, not the address verification.
+    # 'high' = exact / alias hit. 'low' = above threshold but with name-level
+    # edits — the dashboard surfaces low-confidence claims for extra-doc review.
+    confidence = 'high' if score >= HIGH_CONFIDENCE_THRESHOLD else 'low'
+    portal_url = build_portal_url(records, confidence)
+    return json.dumps({
+        'refunds': results,
+        'portal_url': portal_url,
+        'confidence': confidence,
+        'match_score': round(score, 3),
+    })
 
 
 def lambda_handler(event: dict[str, Any], _context: Any) -> dict[str, Any]:

--- a/bot/upload_handler/lambda_function.py
+++ b/bot/upload_handler/lambda_function.py
@@ -514,6 +514,7 @@ def _handle_status(event: dict[str, Any], headers: dict[str, str]) -> dict[str, 
                 "refundType": item.get("refundType", ""),
                 "statuses": statuses,
                 "documents": docs,
+                "confidence": item.get("confidence", "high"),
                 "submittedAt": item.get("submittedAt", ""),
                 "departments": depts_out,
                 "tasksByDepartment": tasks_by_dept,
@@ -723,6 +724,12 @@ def _handle_upload(event: dict[str, Any], headers: dict[str, str]) -> dict[str, 
     name = (body.get("name") or "").strip()
     refund_type = (body.get("refundType") or "").strip()
     files = body.get("files") or []
+    # Confidence is the name-match strength from tax_lookup. Defaults to "high"
+    # (claimant arrived via portal directly without going through chat) so the
+    # admin queue isn't flooded with low-confidence flags from non-bot traffic.
+    confidence = (body.get("confidence") or "high").strip().lower()
+    if confidence not in ("high", "low"):
+        confidence = "high"
 
     if not name or not refund_type:
         return _err(400, "name and refundType are required", headers)
@@ -765,6 +772,7 @@ def _handle_upload(event: dict[str, Any], headers: dict[str, str]) -> dict[str, 
             "departments": departments,
             "statuses": {d: "partial" for d in departments},
             "documents": [],
+            "confidence": confidence,
             "submittedAt": now,
             "updatedAt": now,
         })

--- a/bot/upload_portal/index.html
+++ b/bot/upload_portal/index.html
@@ -439,6 +439,9 @@
             var presetAddress = params.get("address") || "";
             var presetAssessment = params.get("assessment") || "";
             var presetTaxYear = params.get("taxyear") || "";
+            // Confidence: 'high' | 'low' | '' — set by tax_lookup. Persisted on
+            // submission so the admin dashboard can flag low-confidence claims.
+            var presetConfidence = (params.get("confidence") || "").toLowerCase();
 
             var formSections = document.getElementById("formSections");
             var docTitle = document.getElementById("docTitle");
@@ -999,6 +1002,7 @@
                             name: name,
                             refundType: refundType,
                             files: filesToUpload,
+                            confidence: presetConfidence || undefined,
                         }),
                     });
                     var data = await res.json();


### PR DESCRIPTION
Adds a confidence score to the fuzzy name matcher and surfaces low-confidence hits as an "⚠ extra docs" flag in the admin dashboard so staff know to request additional supporting documents.