### PR TITLE
fix: consistent submission ID, hide type from non-super-admins, dedupe refund tags

### DIFF
--- a/admin-dashboard/app/dashboard/page.tsx
+++ b/admin-dashboard/app/dashboard/page.tsx
@@ -201,7 +201,7 @@ export default function DashboardPage() {
           <TableHeader>
             <TableRow>
               <TableHead>Name</TableHead>
-              <TableHead>Type</TableHead>
+              {perms?.isSuperAdmin && <TableHead>Type</TableHead>}
               <TableHead>Departments</TableHead>
               <TableHead>Status</TableHead>
               <TableHead>Tasks</TableHead>
@@ -232,11 +232,13 @@ export default function DashboardPage() {
                       )}
                     </div>
                   </TableCell>
-                  <TableCell>
-                    {Array.from(new Set(s.refundType.split(","))).map((t) => (
-                      <Badge key={t} variant="secondary" className="mr-1">{labelFor(t, labels)}</Badge>
-                    ))}
-                  </TableCell>
+                  {perms?.isSuperAdmin && (
+                    <TableCell>
+                      {Array.from(new Set(s.refundType.split(","))).map((t) => (
+                        <Badge key={t} variant="secondary" className="mr-1">{labelFor(t, labels)}</Badge>
+                      ))}
+                    </TableCell>
+                  )}
                   <TableCell>
                     {s.departments.length ? s.departments.map((d) => (
                       <Badge key={d} variant="outline" className="mr-1">{d}</Badge>

--- a/bot/upload_handler/lambda_function.py
+++ b/bot/upload_handler/lambda_function.py
@@ -746,6 +746,11 @@ def _handle_upload(event: dict[str, Any], headers: dict[str, str]) -> dict[str, 
     confidence = (body.get("confidence") or "high").strip().lower()
     if confidence not in ("high", "low"):
         confidence = "high"
+    # Accept a pre-reserved submissionId from the claimant portal so the ID
+    # shown to the user before submit matches the one stored after submit.
+    submission_id = (body.get("submissionId") or "").strip()
+    if not submission_id:
+        submission_id = uuid.uuid4().hex[:12]
 
     if not name or not refund_type:
         return _err(400, "name and refundType are required", headers)
@@ -753,7 +758,6 @@ def _handle_upload(event: dict[str, Any], headers: dict[str, str]) -> dict[str, 
         return _err(400, "Provide 1-5 files", headers)
 
     urls = []
-    submission_id = uuid.uuid4().hex[:12]
     now = _now_iso()
 
     for f in files:

--- a/claimant-portal/app/new/page.tsx
+++ b/claimant-portal/app/new/page.tsx
@@ -401,39 +401,19 @@ export default function NewClaimPage() {
         ...files.map((f) => ({ filename: f.name, contentType: f.type || "application/octet-stream" })),
       ];
 
-      // POST /upload to get presigned URLs (or reuse reservedId)
-      let sid = reservedId;
-      let uploadSlots: UploadSlot[] = [];
-
-      if (sid) {
-        // Already reserved — just get upload URLs via /upload-continue if available,
-        // but since that requires a token we don't have yet, use /upload to create
-        // a new presigned set (the form data is separate from the DynamoDB record).
-        // We'll POST /upload with the same name/refundType so the S3 folder matches.
-        // NOTE: The reservation created the DynamoDB record; we still need S3 urls.
-        const uploadRes = await apiFetch<{ submissionId: string; uploads: UploadSlot[] }>(
-          "/upload",
-          {
-            method: "POST",
-            body: JSON.stringify({ name, refundType, address, files: fileList }),
-          },
-        );
-        // Use the pre-reserved submissionId for DynamoDB but upload to the new S3 folder.
-        // To keep it simple: we accept the submissionId from /upload (which is new).
-        // The reserved one is in DDB but we'll use the upload one going forward.
-        sid = uploadRes.submissionId;
-        uploadSlots = uploadRes.uploads;
-      } else {
-        const uploadRes = await apiFetch<{ submissionId: string; uploads: UploadSlot[] }>(
-          "/upload",
-          {
-            method: "POST",
-            body: JSON.stringify({ name, refundType, address, files: fileList }),
-          },
-        );
-        sid = uploadRes.submissionId;
-        uploadSlots = uploadRes.uploads;
-      }
+      // POST /upload to get presigned URLs, passing the reserved ID so the
+      // backend reuses it instead of generating a new one.
+      const uploadBody: Record<string, unknown> = { name, refundType, address, files: fileList };
+      if (reservedId) uploadBody.submissionId = reservedId;
+      const uploadRes = await apiFetch<{ submissionId: string; uploads: UploadSlot[] }>(
+        "/upload",
+        {
+          method: "POST",
+          body: JSON.stringify(uploadBody),
+        },
+      );
+      const sid = uploadRes.submissionId;
+      const uploadSlots: UploadSlot[] = uploadRes.uploads;
 
       // Upload files to S3 presigned URLs
       const unifiedSlot = uploadSlots.find((u) => u.filename === "unified-form.json");


### PR DESCRIPTION
Reuses the reserved submission ID on form submit so the claimant sees the same ID before and after submitting, hides the refund type column from non-super-admin users, and deduplicates refund type badges when a submission has multiple records of the same type.