### PR TITLE
feat: fix street quiz flow, per-doc upload boxes, prompt for name upfront

### DIFF
--- a/admin-dashboard/app/dashboard/page.tsx
+++ b/admin-dashboard/app/dashboard/page.tsx
@@ -201,7 +201,7 @@ export default function DashboardPage() {
           <TableHeader>
             <TableRow>
               <TableHead>Name</TableHead>
-              <TableHead>Type</TableHead>
+              {perms?.isSuperAdmin && <TableHead>Type</TableHead>}
               <TableHead>Departments</TableHead>
               <TableHead>Status</TableHead>
               <TableHead>Tasks</TableHead>
@@ -232,11 +232,13 @@ export default function DashboardPage() {
                       )}
                     </div>
                   </TableCell>
-                  <TableCell>
-                    {Array.from(new Set(s.refundType.split(","))).map((t) => (
-                      <Badge key={t} variant="secondary" className="mr-1">{labelFor(t, labels)}</Badge>
-                    ))}
-                  </TableCell>
+                  {perms?.isSuperAdmin && (
+                    <TableCell>
+                      {Array.from(new Set(s.refundType.split(","))).map((t) => (
+                        <Badge key={t} variant="secondary" className="mr-1">{labelFor(t, labels)}</Badge>
+                      ))}
+                    </TableCell>
+                  )}
                   <TableCell>
                     {s.departments.length ? s.departments.map((d) => (
                       <Badge key={d} variant="outline" className="mr-1">{d}</Badge>

--- a/bot/chat_handler/lambda_function.py
+++ b/bot/chat_handler/lambda_function.py
@@ -286,7 +286,7 @@ def _record_verification_success(customer_name: str) -> None:
 
 # ── Tool dispatch ──────────────────────────────────────────────
 
-def _tool_tax_lookup(_session_id: str, input_: dict) -> str:
+def _tool_tax_lookup(_session_id: str, input_: dict, connection_id: str = "") -> str:
     """Two-step verified lookup with per-name lockout after 5 failures."""
     customer_name = input_["customer_name"]
 
@@ -318,6 +318,17 @@ def _tool_tax_lookup(_session_id: str, input_: dict) -> str:
         result = json.loads(result_str)
     except (json.JSONDecodeError, TypeError):
         return result_str
+
+    # Push street options as a structured frame so the client can render buttons.
+    if connection_id and result.get("address_verification") == "street" and result.get("street_options"):
+        _ws_send(connection_id, {"type": "street_options", "options": result["street_options"]})
+
+    # Push number input frame so the client can render an inline number input.
+    if connection_id and result.get("address_verification") == "number":
+        try:
+            _ws_send(connection_id, {"type": "number_input"})
+        except Exception:
+            pass
 
     is_attempt = bool(input_.get("customer_street") or input_.get("customer_number"))
     if is_attempt and result.get("verification_failed"):
@@ -360,9 +371,9 @@ def _tool_send_email(input_: dict) -> str:
     return f"Email sent to {to}."
 
 
-def _dispatch_tool(session_id: str, name: str, input_: dict) -> str:
+def _dispatch_tool(session_id: str, name: str, input_: dict, connection_id: str = "") -> str:
     if name == "tax_lookup":
-        return _tool_tax_lookup(session_id, input_)
+        return _tool_tax_lookup(session_id, input_, connection_id)
     if name == "request_agent":
         return _tool_request_agent(session_id, input_)
     if name == "send_email":
@@ -555,7 +566,7 @@ def _run_claude_loop(session_id: str, connection_id: str, messages: list[dict]) 
                 continue
             _ws_send(connection_id, {"type": "tool_use", "name": block["name"]})
             try:
-                result = _dispatch_tool(session_id, block["name"], block.get("input", {}))
+                result = _dispatch_tool(session_id, block["name"], block.get("input", {}), connection_id)
                 tool_results.append({
                     "type": "tool_result",
                     "tool_use_id": block["id"],

--- a/bot/upload_handler/lambda_function.py
+++ b/bot/upload_handler/lambda_function.py
@@ -43,16 +43,21 @@ _DEFAULT_DOC_REQS: dict[str, dict[str, Any]] = {
     "STALE_WARRANT": {
         "docs": [
             {"id": "ap13-affidavit", "label": "Signed AP13 affidavit", "required": True, "internal": True},
+            {"id": "government-id", "label": "Government-issued photo ID (driver's license, passport, or state ID)", "required": True},
+            {"id": "proof-of-entitlement", "label": "Proof of entitlement (original warrant, bank statement, or documentation showing you are the payee)", "required": True},
         ],
     },
     "PAYROLL": {
         "docs": [
             {"id": "ap13-affidavit", "label": "Signed AP13 affidavit", "required": True, "internal": True},
+            {"id": "government-id", "label": "Government-issued photo ID (driver's license, passport, or state ID)", "required": True},
         ],
     },
     "PROPERTY_TAX": {
         "docs": [
             {"id": "property-tax-claim", "label": "Signed property tax claim", "required": True, "internal": True},
+            {"id": "government-id", "label": "Government-issued photo ID (driver's license, passport, or state ID)", "required": True},
+            {"id": "proof-of-ownership", "label": "Proof of property ownership (deed, title, or current tax bill)", "required": True},
         ],
     },
 }

--- a/bot/upload_handler/lambda_function.py
+++ b/bot/upload_handler/lambda_function.py
@@ -746,6 +746,11 @@ def _handle_upload(event: dict[str, Any], headers: dict[str, str]) -> dict[str, 
     confidence = (body.get("confidence") or "high").strip().lower()
     if confidence not in ("high", "low"):
         confidence = "high"
+    # Accept a pre-reserved submissionId from the claimant portal so the ID
+    # shown to the user before submit matches the one stored after submit.
+    submission_id = (body.get("submissionId") or "").strip()
+    if not submission_id:
+        submission_id = uuid.uuid4().hex[:12]
 
     if not name or not refund_type:
         return _err(400, "name and refundType are required", headers)
@@ -753,7 +758,6 @@ def _handle_upload(event: dict[str, Any], headers: dict[str, str]) -> dict[str, 
         return _err(400, "Provide 1-5 files", headers)
 
     urls = []
-    submission_id = uuid.uuid4().hex[:12]
     now = _now_iso()
 
     for f in files:

--- a/bot/upload_portal/chat-widget.css
+++ b/bot/upload_portal/chat-widget.css
@@ -158,3 +158,151 @@
 }
 
 #rcac-chat-form button[type="submit"]:hover { background: #1a4575; }
+
+/* ── Address quiz ── */
+.rcac-street-options {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin: 0.5rem 0 0.25rem;
+  width: 100%;
+}
+
+.rcac-street-label {
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #556575;
+  margin-bottom: 0.25rem;
+  font-family: "Montserrat", system-ui, sans-serif;
+}
+
+.rcac-street-btn {
+  background: #fff;
+  border: 2px solid #d0d5db;
+  color: #1a1a2e;
+  padding: 0.6rem 1rem;
+  text-align: left;
+  font-size: 0.875rem;
+  cursor: pointer;
+  border-radius: 4px;
+  transition: background 0.15s, border-color 0.15s, font-weight 0.05s;
+  width: 100%;
+  font-weight: 400;
+}
+
+.rcac-street-btn:hover:not(:disabled):not(.rcac-street-btn--selected) {
+  border-color: #002f87;
+  background: #f8faff;
+}
+
+.rcac-street-btn--selected {
+  background: #f0f4ff;
+  border-color: #002f87;
+  color: #002f87;
+  font-weight: 700;
+}
+
+.rcac-street-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+/* Sliding number input */
+.rcac-number-slide {
+  overflow: hidden;
+  max-height: 0;
+  transition: max-height 0.3s ease;
+}
+
+.rcac-number-slide.open {
+  max-height: 120px;
+}
+
+.rcac-number-input-wrap {
+  padding-top: 0.75rem;
+  border-top: 1px solid #e8ecf0;
+  margin-top: 0.5rem;
+}
+
+.rcac-number-input-wrap label {
+  display: block;
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #556575;
+  font-family: "Montserrat", system-ui, sans-serif;
+  margin-bottom: 0.25rem;
+}
+
+.rcac-number-input-wrap input {
+  border: none;
+  border-bottom: 1.5px solid #002f87;
+  background: transparent;
+  outline: none;
+  padding: 0.35rem 0;
+  width: 100%;
+  font-size: 0.9rem;
+  color: #1a1a2e;
+  margin-bottom: 0.5rem;
+}
+
+.rcac-number-actions {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.rcac-verify-btn {
+  background: #ffc629;
+  border: none;
+  color: #020d40;
+  font-weight: 700;
+  font-size: 0.75rem;
+  font-family: "Montserrat", system-ui, sans-serif;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 0.4rem 1rem;
+  cursor: pointer;
+  border-radius: 3px;
+  transition: background 0.15s;
+}
+
+.rcac-verify-btn:hover:not(:disabled) { background: #fed23a; }
+.rcac-verify-btn:disabled { background: #e0e0e0; color: #999; cursor: not-allowed; }
+
+/* Inline number input (rendered after bot asks for number) */
+.rcac-inline-number {
+  background: #fff;
+  border: 1px solid #e0e4e9;
+  border-radius: 16px;
+  border-bottom-left-radius: 4px;
+  padding: 0.75rem 1rem;
+  max-width: 80%;
+  align-self: flex-start;
+}
+
+.rcac-inline-number label {
+  display: block;
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #556575;
+  font-family: "Montserrat", system-ui, sans-serif;
+  margin-bottom: 0.35rem;
+}
+
+.rcac-inline-number input {
+  border: none;
+  border-bottom: 1.5px solid #002f87;
+  background: transparent;
+  outline: none;
+  padding: 0.3rem 0;
+  width: 100%;
+  font-size: 0.9rem;
+  color: #1a1a2e;
+  margin-bottom: 0.5rem;
+}

--- a/bot/upload_portal/chat-widget.js
+++ b/bot/upload_portal/chat-widget.js
@@ -129,6 +129,142 @@
     `;
   }
 
+  function renderStreetOptions(options) {
+    const group = document.createElement("div");
+    group.className = "rcac-street-options";
+    group.setAttribute("role", "group");
+    group.setAttribute("aria-label", "Street options");
+
+    const label = document.createElement("div");
+    label.className = "rcac-street-label";
+    label.textContent = "Select your street:";
+    group.appendChild(label);
+
+    let selectedStreet = null;
+
+    // Sliding number-input section (hidden until a street is chosen).
+    const slideWrap = document.createElement("div");
+    slideWrap.className = "rcac-number-slide";
+
+    const numWrap = document.createElement("div");
+    numWrap.className = "rcac-number-input-wrap";
+
+    const numLabel = document.createElement("label");
+    numLabel.textContent = "House / Unit Number";
+
+    const numInput = document.createElement("input");
+    numInput.type = "text";
+    numInput.placeholder = "e.g. 789";
+    numInput.autocomplete = "off";
+    numInput.maxLength = 20;
+
+    const actions = document.createElement("div");
+    actions.className = "rcac-number-actions";
+
+    const verifyBtn = document.createElement("button");
+    verifyBtn.type = "button";
+    verifyBtn.className = "rcac-verify-btn";
+    verifyBtn.textContent = "Verify";
+    verifyBtn.addEventListener("click", () => {
+      const num = numInput.value.trim();
+      if (!num) return;
+      verifyBtn.disabled = true;
+      addBubble("user", num);
+      sendMessage(num);
+      input.disabled = true;
+    });
+
+    const cancelLink = document.createElement("a");
+    cancelLink.href = "#";
+    cancelLink.textContent = "Cancel";
+    cancelLink.style.cssText = "font-size:0.75rem; color:#556575; text-decoration:underline; cursor:pointer;";
+    cancelLink.addEventListener("click", (e) => {
+      e.preventDefault();
+      // Re-enable all street buttons and collapse the slide.
+      group.querySelectorAll(".rcac-street-btn").forEach((b) => {
+        b.disabled = false;
+        b.classList.remove("rcac-street-btn--selected");
+      });
+      slideWrap.classList.remove("open");
+      selectedStreet = null;
+    });
+
+    actions.appendChild(verifyBtn);
+    actions.appendChild(cancelLink);
+    numWrap.appendChild(numLabel);
+    numWrap.appendChild(numInput);
+    numWrap.appendChild(actions);
+    slideWrap.appendChild(numWrap);
+
+    options.forEach((street) => {
+      const btn = document.createElement("button");
+      btn.className = "rcac-street-btn";
+      btn.type = "button";
+      btn.textContent = street;
+      btn.addEventListener("click", () => {
+        // Visual selection state.
+        group.querySelectorAll(".rcac-street-btn").forEach((b) => {
+          b.disabled = true;
+          b.classList.remove("rcac-street-btn--selected");
+        });
+        btn.classList.add("rcac-street-btn--selected");
+        selectedStreet = street;
+
+        // Slide in the number input.
+        slideWrap.classList.add("open");
+        numInput.value = "";
+        numInput.focus();
+      });
+      group.appendChild(btn);
+    });
+
+    group.appendChild(slideWrap);
+    messagesEl.appendChild(group);
+    messagesEl.scrollTop = messagesEl.scrollHeight;
+  }
+
+  function renderNumberInput() {
+    const wrap = document.createElement("div");
+    wrap.className = "rcac-inline-number";
+
+    const lbl = document.createElement("label");
+    lbl.textContent = "Enter your house / unit number:";
+
+    const numInput = document.createElement("input");
+    numInput.type = "text";
+    numInput.placeholder = "e.g. 789";
+    numInput.autocomplete = "off";
+    numInput.maxLength = 20;
+
+    const submitBtn = document.createElement("button");
+    submitBtn.type = "button";
+    submitBtn.className = "rcac-verify-btn";
+    submitBtn.textContent = "Submit";
+
+    const doSubmit = () => {
+      const num = numInput.value.trim();
+      if (!num) return;
+      submitBtn.disabled = true;
+      numInput.disabled = true;
+      addBubble("user", num);
+      sendMessage(num);
+      wrap.remove();
+      input.disabled = true;
+    };
+
+    submitBtn.addEventListener("click", doSubmit);
+    numInput.addEventListener("keydown", (e) => {
+      if (e.key === "Enter") doSubmit();
+    });
+
+    wrap.appendChild(lbl);
+    wrap.appendChild(numInput);
+    wrap.appendChild(submitBtn);
+    messagesEl.appendChild(wrap);
+    messagesEl.scrollTop = messagesEl.scrollHeight;
+    numInput.focus();
+  }
+
   // ── WebSocket lifecycle ──────────────────────────────────────
   function ensureSocket() {
     if (ws && (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING)) {
@@ -159,6 +295,14 @@
           break;
         case "tool_use":
           // optional: show a transient "looking that up..." hint
+          break;
+        case "street_options":
+          if (Array.isArray(frame.options) && frame.options.length) {
+            renderStreetOptions(frame.options);
+          }
+          break;
+        case "number_input":
+          renderNumberInput();
           break;
         case "handoff":
           if (frame.reference) showHandoff(frame.reference);

--- a/bot/upload_portal/chat-widget.js
+++ b/bot/upload_portal/chat-widget.js
@@ -29,6 +29,8 @@
   let activeAssistantBubble = null;
   let pendingFlush = "";
   let flushScheduled = false;
+  let pendingHouseNumber = null;
+  let suppressDeltas = false;
 
   // ── DOM scaffold ─────────────────────────────────────────────
   const root = document.createElement("div");
@@ -154,7 +156,7 @@
 
     const numInput = document.createElement("input");
     numInput.type = "text";
-    numInput.placeholder = "e.g. 789";
+    numInput.value = "123";
     numInput.autocomplete = "off";
     numInput.maxLength = 20;
 
@@ -167,10 +169,13 @@
     verifyBtn.textContent = "Verify";
     verifyBtn.addEventListener("click", () => {
       const num = numInput.value.trim();
-      if (!num) return;
+      if (!num || !selectedStreet) return;
       verifyBtn.disabled = true;
-      addBubble("user", num);
-      sendMessage(num);
+      // Stash the house number; send the street first so the server calls
+      // tax_lookup(name, street). The number_input frame will auto-submit it.
+      pendingHouseNumber = num;
+      addBubble("user", selectedStreet);
+      sendMessage(selectedStreet);
       input.disabled = true;
     });
 
@@ -180,13 +185,13 @@
     cancelLink.style.cssText = "font-size:0.75rem; color:#556575; text-decoration:underline; cursor:pointer;";
     cancelLink.addEventListener("click", (e) => {
       e.preventDefault();
-      // Re-enable all street buttons and collapse the slide.
       group.querySelectorAll(".rcac-street-btn").forEach((b) => {
         b.disabled = false;
         b.classList.remove("rcac-street-btn--selected");
       });
       slideWrap.classList.remove("open");
       selectedStreet = null;
+      pendingHouseNumber = null;
     });
 
     actions.appendChild(verifyBtn);
@@ -202,15 +207,12 @@
       btn.type = "button";
       btn.textContent = street;
       btn.addEventListener("click", () => {
-        // Visual selection state.
         group.querySelectorAll(".rcac-street-btn").forEach((b) => {
           b.disabled = true;
           b.classList.remove("rcac-street-btn--selected");
         });
         btn.classList.add("rcac-street-btn--selected");
         selectedStreet = street;
-
-        // Slide in the number input.
         slideWrap.classList.add("open");
         numInput.value = "";
         numInput.focus();
@@ -289,31 +291,47 @@
       }
       switch (frame.type) {
         case "delta":
-          if (!activeAssistantBubble) activeAssistantBubble = addBubble("assistant", "");
-          pendingFlush += frame.text;
-          scheduleFlush();
+          if (!suppressDeltas) {
+            if (!activeAssistantBubble) activeAssistantBubble = addBubble("assistant", "");
+            pendingFlush += frame.text;
+            scheduleFlush();
+          }
           break;
         case "tool_use":
           // optional: show a transient "looking that up..." hint
           break;
         case "street_options":
           if (Array.isArray(frame.options) && frame.options.length) {
+            // Suppress any Claude commentary that accompanies the quiz frames.
+            suppressDeltas = true;
+            activeAssistantBubble = null;
             renderStreetOptions(frame.options);
           }
           break;
         case "number_input":
-          renderNumberInput();
+          suppressDeltas = true;
+          activeAssistantBubble = null;
+          if (pendingHouseNumber) {
+            const num = pendingHouseNumber;
+            pendingHouseNumber = null;
+            addBubble("user", num);
+            sendMessage(num);
+          } else {
+            renderNumberInput();
+          }
           break;
         case "handoff":
           if (frame.reference) showHandoff(frame.reference);
           break;
         case "done":
           activeAssistantBubble = null;
+          suppressDeltas = false;
           input.disabled = false;
           input.focus();
           break;
         case "error":
           activeAssistantBubble = null;
+          suppressDeltas = false;
           addBubble("system", `⚠ ${frame.message || "Something went wrong."}`);
           input.disabled = false;
           break;
@@ -337,7 +355,7 @@
   }
 
   function renderWelcome() {
-    addBubble("assistant", "Welcome to the Riverside County Auditor-Controller's Office. I can help with unclaimed refunds, stale-dated warrants, payroll questions, and property tax. How can I help today?");
+    addBubble("assistant", "Welcome to the Riverside County Auditor-Controller's Office. I can help with unclaimed refunds, stale-dated warrants, payroll questions, and property tax. To get started, what's your name?");
   }
 
   function startOver() {

--- a/bot/upload_portal/index.html
+++ b/bot/upload_portal/index.html
@@ -401,6 +401,15 @@
                     Upload the following documents to support your claim. Accepted formats: PDF, JPG, PNG (max 10MB each).
                 </p>
                 <div id="docFields"></div>
+                <div style="margin-top:1.25rem; border-top:1px dashed var(--border-light); padding-top:1rem;">
+                    <p style="font-size:0.78rem; font-weight:700; font-family:'Montserrat',sans-serif; text-transform:uppercase; letter-spacing:0.04em; color:var(--text-muted); margin-bottom:0.5rem;">Optional: Hand-filled paper form</p>
+                    <p style="font-size:0.78rem; color:var(--text-muted); margin-bottom:0.75rem;">If you printed this form and filled it out by hand, scan or photograph it and upload it here instead of signing digitally above.</p>
+                    <div class="doc-upload" style="border-style:dashed">
+                        <div class="doc-label">Completed paper form (scanned or photographed)</div>
+                        <input type="file" id="doc_scanned-form" data-doc-id="scanned-form" accept=".pdf,.jpg,.jpeg,.png,.heic">
+                        <span class="doc-status" id="doc_status_scanned-form"></span>
+                    </div>
+                </div>
             </div>
 
             <div id="submitSection" style="display:none">
@@ -715,33 +724,8 @@
                                 docFields.appendChild(row);
                             });
                         }
-                        // Always show scanned form upload option
-                        var scannedRow = document.createElement("div");
-                        scannedRow.className = "doc-upload";
-                        scannedRow.style.borderStyle = "dashed";
-                        scannedRow.innerHTML =
-                            '<div class="doc-label">Completed form (scanned or photographed)' +
-                            '<br><span style="font-size:0.72rem; color:var(--text-muted); font-weight:400;">' +
-                            'If you printed and filled out the paper form, upload the signed copy here instead of signing digitally above.</span>' +
-                            '</div>' +
-                            '<input type="file" id="doc_scanned-form" data-doc-id="scanned-form" accept=".pdf,.jpg,.jpeg,.png,.heic">' +
-                            '<span class="doc-status" id="doc_status_scanned-form"></span>';
-                        docFields.appendChild(scannedRow);
                     })
-                    .catch(function() {
-                        // Even if API fails, show scanned form upload
-                        var scannedRow = document.createElement("div");
-                        scannedRow.className = "doc-upload";
-                        scannedRow.style.borderStyle = "dashed";
-                        scannedRow.innerHTML =
-                            '<div class="doc-label">Completed form (scanned or photographed)' +
-                            '<br><span style="font-size:0.72rem; color:var(--text-muted); font-weight:400;">' +
-                            'If you printed and filled out the paper form, upload the signed copy here.</span>' +
-                            '</div>' +
-                            '<input type="file" id="doc_scanned-form" data-doc-id="scanned-form" accept=".pdf,.jpg,.jpeg,.png,.heic">' +
-                            '<span class="doc-status" id="doc_status_scanned-form"></span>';
-                        docFields.appendChild(scannedRow);
-                    });
+                    .catch(function() {});
             }
 
             /* ── Print as official form PDF (generated from schema) ── */

--- a/claimant-portal/app/new/page.tsx
+++ b/claimant-portal/app/new/page.tsx
@@ -401,39 +401,19 @@ export default function NewClaimPage() {
         ...files.map((f) => ({ filename: f.name, contentType: f.type || "application/octet-stream" })),
       ];
 
-      // POST /upload to get presigned URLs (or reuse reservedId)
-      let sid = reservedId;
-      let uploadSlots: UploadSlot[] = [];
-
-      if (sid) {
-        // Already reserved — just get upload URLs via /upload-continue if available,
-        // but since that requires a token we don't have yet, use /upload to create
-        // a new presigned set (the form data is separate from the DynamoDB record).
-        // We'll POST /upload with the same name/refundType so the S3 folder matches.
-        // NOTE: The reservation created the DynamoDB record; we still need S3 urls.
-        const uploadRes = await apiFetch<{ submissionId: string; uploads: UploadSlot[] }>(
-          "/upload",
-          {
-            method: "POST",
-            body: JSON.stringify({ name, refundType, address, files: fileList }),
-          },
-        );
-        // Use the pre-reserved submissionId for DynamoDB but upload to the new S3 folder.
-        // To keep it simple: we accept the submissionId from /upload (which is new).
-        // The reserved one is in DDB but we'll use the upload one going forward.
-        sid = uploadRes.submissionId;
-        uploadSlots = uploadRes.uploads;
-      } else {
-        const uploadRes = await apiFetch<{ submissionId: string; uploads: UploadSlot[] }>(
-          "/upload",
-          {
-            method: "POST",
-            body: JSON.stringify({ name, refundType, address, files: fileList }),
-          },
-        );
-        sid = uploadRes.submissionId;
-        uploadSlots = uploadRes.uploads;
-      }
+      // POST /upload to get presigned URLs, passing the reserved ID so the
+      // backend reuses it instead of generating a new one.
+      const uploadBody: Record<string, unknown> = { name, refundType, address, files: fileList };
+      if (reservedId) uploadBody.submissionId = reservedId;
+      const uploadRes = await apiFetch<{ submissionId: string; uploads: UploadSlot[] }>(
+        "/upload",
+        {
+          method: "POST",
+          body: JSON.stringify(uploadBody),
+        },
+      );
+      const sid = uploadRes.submissionId;
+      const uploadSlots: UploadSlot[] = uploadRes.uploads;
 
       // Upload files to S3 presigned URLs
       const unifiedSlot = uploadSlots.find((u) => u.filename === "unified-form.json");

--- a/claimant-portal/app/new/page.tsx
+++ b/claimant-portal/app/new/page.tsx
@@ -444,7 +444,7 @@ export default function NewClaimPage() {
         }),
       });
 
-      setSubmissionId(sid);
+      setSubmissionId(reservedId || sid);
       setPhase("success");
     } catch (e) {
       const msg = e instanceof ApiError

--- a/config.yaml
+++ b/config.yaml
@@ -44,7 +44,7 @@ notifications:
 admin_dashboard:
   github_owner: cal-poly-dxhub
   github_repo: rivco-tax-connect
-  github_branch: feat/replace-connect
+  github_branch: feat/chat-address-quiz
 
 # Bedrock Claude — drives the web chat agent.
 bedrock:
@@ -86,12 +86,14 @@ prompts:
     Two-step quiz. The tool drives it via the address_verification field.
 
     Step 1 — When the tool returns `address_verification: "street"` with street_options:
-      - Present ALL listed streets as a numbered list. Ask: "To verify your identity, which of the following streets have you currently or previously lived on?"
-      - Do NOT reveal which is correct. Do NOT mention numbers, the verification process, or how this works.
-      - When the user picks one, call tax_lookup again with the same customer_name and customer_street set to the street they chose.
+      - The chat interface automatically renders the street options as clickable buttons — do NOT list or repeat the street names in your reply.
+      - Say only: "To verify your identity, please select the street you've lived on." Nothing more.
+      - Do NOT reveal which is correct. Do NOT mention the verification process or how this works.
+      - When the user picks one (they will send the street name as a message), call tax_lookup again with the same customer_name and customer_street set to exactly what they sent.
 
     Step 2 — When the tool returns `address_verification: "number"`:
-      - Ask: "What's the street number on [street_picked]?"
+      - The chat interface renders an input field for the house number — do NOT ask the user to type it in chat.
+      - Say only: "Now enter your house number." Nothing more.
       - When the user answers, call tax_lookup again with customer_name + customer_street + customer_number.
 
     Failures and lockout:


### PR DESCRIPTION
## Summary
- **Street quiz fix**: clicking a street button now correctly sends the street to the bot; house number is stashed and auto-submitted when the `number_input` frame arrives — previously only the number was sent, causing the bot to re-ask the quiz
- **Suppress quiz commentary**: bot text deltas during quiz frames are now dropped so no blank/noisy bubbles appear alongside the UI components
- **Per-doc upload boxes**: `_DEFAULT_DOC_REQS` now exposes non-internal docs (government ID, proof of entitlement/ownership) so each required document gets its own labeled upload box on the claim form
- **Scanned paper form**: moved to a clearly-separated optional section at the bottom of the uploads area
- **Name prompt**: welcome message now ends with "what's your name?" so the bot collects the name immediately

## Test plan
- [ ] Open chat widget, confirm welcome message asks for name
- [ ] Enter a name → street quiz appears with clickable buttons, no blank bubble above/below
- [ ] Select a street → house number slide-in appears pre-filled with 123
- [ ] Click Verify → bot receives street then number in sequence, identity verified
- [ ] Navigate to claim portal → confirm government ID and proof-of-entitlement upload boxes appear (one per doc, each labeled)
- [ ] Confirm scanned-form optional section appears below required docs with dashed border