### PR TITLE
feat: add 'other supporting documents' upload slot on claim form

### DIFF
--- a/cdk/upload_handler/lambda_function.py
+++ b/cdk/upload_handler/lambda_function.py
@@ -760,8 +760,8 @@ def _handle_upload(event: dict[str, Any], headers: dict[str, str]) -> dict[str, 
 
     if not name or not refund_type:
         return _err(400, "name and refundType are required", headers)
-    if not files or len(files) > 5:
-        return _err(400, "Provide 1-5 files", headers)
+    if not files or len(files) > 15:
+        return _err(400, "Provide 1-15 files", headers)
 
     urls = []
     now = _now_iso()

--- a/cdk/upload_portal/index.html
+++ b/cdk/upload_portal/index.html
@@ -410,6 +410,15 @@
                         <span class="doc-status" id="doc_status_scanned-form"></span>
                     </div>
                 </div>
+                <div style="margin-top:1.25rem; border-top:1px dashed var(--border-light); padding-top:1rem;">
+                    <p style="font-size:0.78rem; font-weight:700; font-family:'Montserrat',sans-serif; text-transform:uppercase; letter-spacing:0.04em; color:var(--text-muted); margin-bottom:0.5rem;">Optional: Other supporting documents</p>
+                    <p style="font-size:0.78rem; color:var(--text-muted); margin-bottom:0.75rem;">Attach any additional evidence you'd like staff to review (correspondence, payment records, etc.). You can select multiple files at once.</p>
+                    <div class="doc-upload" style="border-style:dashed">
+                        <div class="doc-label">Additional documents</div>
+                        <input type="file" id="doc_other" data-doc-id="other" accept=".pdf,.jpg,.jpeg,.png,.heic" multiple>
+                        <span class="doc-status" id="doc_status_other"></span>
+                    </div>
+                </div>
             </div>
 
             <div id="submitSection" style="display:none">
@@ -969,13 +978,18 @@
                 var fileBlobs = [unifiedBlob];
                 var docInputs = document.querySelectorAll("[data-doc-id]");
                 docInputs.forEach(function(input) {
-                    if (input.files && input.files.length > 0) {
-                        var file = input.files[0];
+                    if (!input.files || input.files.length === 0) return;
+                    var docId = input.dataset.docId;
+                    // Multi-file inputs (e.g. "other") need per-file suffixes so
+                    // multiple uploads don't collide on the same S3 key.
+                    var multi = input.multiple && input.files.length > 1;
+                    Array.prototype.forEach.call(input.files, function(file, idx) {
                         var ext = file.name.split(".").pop().toLowerCase();
-                        var safeName = input.dataset.docId + "." + ext;
+                        var base = multi ? docId + "-" + (idx + 1) : docId;
+                        var safeName = base + "." + ext;
                         filesToUpload.push({ filename: safeName, contentType: file.type || "application/octet-stream" });
                         fileBlobs.push(file);
-                    }
+                    });
                 });
 
                 try {


### PR DESCRIPTION
## Summary
- The upload portal already lists per-refund-type required documents with "Required" badges (driven by `/doc-requirements`). What was missing: a place to attach extras that aren't on the per-type checklist — correspondence, payment records, etc.
- New optional, multi-file **Other supporting documents** box below the existing scanned-form fallback. Per-file suffixes (`other-1.pdf`, `other-2.pdf`) prevent S3 key collisions across multiple selections.
- Submit JS now iterates `input.files` (not just `files[0]`) so multi-file inputs upload all selected files.
- Raise the `/upload` cap from 5 → 15 files — required docs (up to 3) + form JSON + scanned-form + several "other" attachments would otherwise hit the old limit.

Addresses the first "address now" TODO item.

## Test plan
- [ ] Open the claim form for a refund type with required docs — confirm the existing per-doc boxes still render with Required badges
- [ ] Confirm a new "Other supporting documents" box appears below the scanned-form fallback
- [ ] Select multiple files in the Other box and submit — confirm all files appear in S3 as `other-1.{ext}`, `other-2.{ext}`, etc.
- [ ] Confirm the admin dashboard lists every uploaded file (including the `other-N` files) in the file panel
- [ ] Submit with 10+ files — confirm /upload accepts and doesn't 400