### PR TITLE
fix: chat full-name detection, address-quiz reliability, AP-13 second signature

### DIFF
--- a/admin-dashboard/lib/pdf-overlay.ts
+++ b/admin-dashboard/lib/pdf-overlay.ts
@@ -129,26 +129,43 @@ export async function renderFilledPdf(
     }
   }
 
-  // Embed signature
+  // Embed signature. The AP-13 has TWO claimant signature boxes:
+  //   - Page 1: "SIGNATURE PayeeBusiness Claimant"   (Sig field, ~ y=225)
+  //   - Page 2: "SIGNATURE PayeeBusiness Claimant_2" (Sig field, ~ y=425)
+  // Both are claimant-signed; only "Signature of Notary Public" is left blank
+  // for the notary in person.
   if (signatureDataUrl) {
     try {
       const sigBytes = dataUrlToBytes(signatureDataUrl)
       const sigImage = await pdfDoc.embedPng(sigBytes)
       const pages = pdfDoc.getPages()
-      const page = pages[0]
       const scaled = sigImage.scaleToFit(250, 28)
-      page.drawImage(sigImage, {
+      // Page 1 — claimant signature on the affidavit body
+      pages[0].drawImage(sigImage, {
         x: 65,
         y: 227,
         width: scaled.width,
         height: scaled.height,
       })
+      // Page 2 — second claimant signature (the wider declaration block)
+      if (pages[1]) {
+        const scaled2 = sigImage.scaleToFit(280, 18)
+        pages[1].drawImage(sigImage, {
+          x: 80,
+          y: 425,
+          width: scaled2.width,
+          height: scaled2.height,
+        })
+      }
     } catch {
       signatureMissing = true
     }
   }
 
-  // Remove the duplicate named fields so they don't render empty boxes
+  // Remove the duplicate named fields so they don't render empty boxes.
+  // Also strip the two claimant Sig fields after we've drawn the image on
+  // top — if pdf-lib leaves them as form fields, flatten() can paint an
+  // empty rectangle over the drawn signature.
   const duplicateFields = [
     "Print Name", "Street Address", "City", "State and ZIP code",
     "City_2", "State", "Date", "NAME PayeeBusiness Name",
@@ -161,6 +178,7 @@ export async function renderFilledPdf(
     "PRINTED NAME Payee Business Name", "undefined",
     "AFFIDAVIT FOR THE REPLACEMENT OF STALE DATED WARRANT OFFICE OF THE AUDITORCONTROLLER",
     "AP  13 Policy  214 Page 2 of 4",
+    "SIGNATURE PayeeBusiness Claimant", "SIGNATURE PayeeBusiness Claimant_2",
   ]
   for (const name of duplicateFields) {
     try { form.removeField(form.getField(name)) } catch {}

--- a/cdk/chat_system_prompt.md
+++ b/cdk/chat_system_prompt.md
@@ -13,7 +13,8 @@ You are a Riverside County Auditor-Controller assistant on the auditorcontroller
 
 **LOOKUP:**
 - Only look up the USER'S OWN refund. If they ask on behalf of a friend/relative/etc., refuse: "For privacy, I can only look up your own refund. The person you're asking about should contact us themselves." Don't call tax_lookup. Exception: legal owners/custodians (estate executors, business officers).
-- If the user gives only a single-word/first name (e.g. "Chris", "Maria"), reply: "Could you share your full name including last name? That helps me find the right record." Don't call tax_lookup yet. A multi-word business name ("Carey Ministries") is fine to look up directly.
+- If the user gives a single-word name (e.g. "Chris", "Maria") with no other words, reply: "Could you share your full name including last name? That helps me find the right record." Don't call tax_lookup yet.
+- If the user gives two or more space-separated words (e.g. "Chris Ryan", "Maria Lopez", "Carey Ministries"), treat that as a full name and call tax_lookup IMMEDIATELY. Do NOT ask the user to confirm — proceed directly to lookup.
 - Once you have a full name, call tax_lookup immediately.
 - If the tool returns disambiguation_needed, list addresses, ask which is theirs, call tax_lookup again with customer_name + customer_address.
 - If no refund found: "We found no refunds for [name]. You may have no refunds or your refund may have passed its claim deadline." Suggest checking spelling.

--- a/cdk/runtime/lambda_function.py
+++ b/cdk/runtime/lambda_function.py
@@ -318,14 +318,31 @@ def _street_matches(claim_street_name: str, real_address: str) -> bool:
 
 
 def _number_matches(claim_number: str, real_address: str) -> bool:
-    """Compare claimant's house-number guess against the real number."""
+    """Compare claimant's house-number guess against the real number.
+
+    Accepts variations users actually type:
+      - leading/trailing whitespace
+      - dashes ("23-19" vs "2319")
+      - leading zeros ("0789" vs "789") — only when the claim is purely numeric
+    Alphanumeric house numbers ("4080A") still need a case-insensitive match
+    on the alphabetic suffix.
+    """
     claim = (claim_number or '').strip()
     if not claim:
         return False
     real_num, _ = split_street_parts(extract_street(real_address))
     if not real_num:
         return False
-    return claim.lower().replace('-', '') == real_num.lower().replace('-', '')
+    norm = lambda s: s.lower().replace('-', '').replace(' ', '')
+    c = norm(claim)
+    r = norm(real_num)
+    if c == r:
+        return True
+    # Strip leading zeros only when both sides are pure digits — keeps
+    # "0789" vs "789" matching but doesn't collapse "4080A" to "480A".
+    if c.isdigit() and r.isdigit():
+        return c.lstrip('0') == r.lstrip('0')
+    return False
 
 
 def lookup(name: str, street: str = '', number: str = '') -> str:
@@ -425,8 +442,10 @@ def lookup(name: str, street: str = '', number: str = '') -> str:
             ),
         })
 
-    # Step 3 — verify number too.
-    if not _number_matches(number, real_address):
+    # Step 3 — verify number too. Some claimants have multiple records on the
+    # same street with different house numbers (rare but real); accept the
+    # number if it matches ANY record's address, not just records[0].
+    if not any(_number_matches(number, r.get('address', '')) for r in records):
         return json.dumps({
             'verification_failed': True,
             'message': (

--- a/claimant-portal/lib/ap13.ts
+++ b/claimant-portal/lib/ap13.ts
@@ -87,13 +87,26 @@ export async function renderAp13Pdf(
     try {
       const sigBytes = dataUrlToBytes(signatureDataUrl);
       const sigImage = await pdfDoc.embedPng(sigBytes);
+      const pages = pdfDoc.getPages();
       const scaled = sigImage.scaleToFit(250, 28);
-      pdfDoc.getPages()[0].drawImage(sigImage, {
+      // Page 1 — claimant signature on the affidavit body.
+      pages[0].drawImage(sigImage, {
         x: 65,
         y: 227,
         width: scaled.width,
         height: scaled.height,
       });
+      // Page 2 — second claimant signature (declaration block). Notary box
+      // stays blank for the notary to sign in person.
+      if (pages[1]) {
+        const scaled2 = sigImage.scaleToFit(280, 18);
+        pages[1].drawImage(sigImage, {
+          x: 80,
+          y: 425,
+          width: scaled2.width,
+          height: scaled2.height,
+        });
+      }
     } catch {
       // fall through — signature may be missing on the printed copy and the
       // claimant signs on paper before it goes to the notary.
@@ -114,6 +127,7 @@ export async function renderAp13Pdf(
     "PRINTED NAME Payee Business Name", "undefined",
     "AFFIDAVIT FOR THE REPLACEMENT OF STALE DATED WARRANT OFFICE OF THE AUDITORCONTROLLER",
     "AP  13 Policy  214 Page 2 of 4",
+    "SIGNATURE PayeeBusiness Claimant", "SIGNATURE PayeeBusiness Claimant_2",
   ];
   for (const name of duplicateFields) {
     try { form.removeField(form.getField(name)); } catch {}


### PR DESCRIPTION
## Summary

Three user-reported bug fixes, one commit each:

1. **Chat re-asked for last name even after the user gave one** (`fix: chat treats any 2+ word name as full name without re-asking`). System prompt now treats any 2+ space-separated input as a full name and proceeds straight to lookup; only single-word inputs trigger the "share your last name" follow-up.

2. **Address-quiz verify could fail despite correct answer** (`fix: address-quiz number check tolerant of leading zeros + multi-record names`).
   - Step 3 now checks the house number against ANY record's address (claimants with multiple warrants on the same street with different numbers used to trip a false negative because only `records[0]` was consulted).
   - `_number_matches` tolerates leading zeros (`0789` vs `789`) and stray whitespace, while preserving alphanumeric house-number behaviour (`4080A`).

3. **AP-13 second claimant signature box was blank** (`fix: AP-13 second claimant signature field now filled`). The PDF has two `/Sig` claimant fields — `SIGNATURE PayeeBusiness Claimant` (page 1) and `..._2` (page 2) — plus a separate notary field. Only page 1 was being drawn. Both `admin-dashboard/lib/pdf-overlay.ts` and `claimant-portal/lib/ap13.ts` now draw the signature image at both coords and strip both `/Sig` field names before `flatten()` so empty boxes don't render over the drawn image. Notary box remains untouched.

Stacked on `feat/notary-threshold-print` (PR #32).

## Test plan

- [ ] Chat: type `chris ryan` — bot should call `tax_lookup` immediately, no "share full name" follow-up.
- [ ] Chat: type `chris` — bot still asks for the last name.
- [ ] Address quiz: pick the right street + correct house number for **MATHEW CLARK** (has 2 records on different streets) — verify passes 100% of the time.
- [ ] Address quiz: enter house number with a leading zero — still verifies.
- [ ] Submit a claim, then check the AP-13 in the admin dashboard's filled-form viewer — both claimant signature boxes should show the embedded signature; notary box stays blank.
- [ ] Print AP-13 on the claimant portal (`>=$1K` warrant flow) — both signature boxes filled if claimant signed digitally first.